### PR TITLE
govendor: update to latest version of vendor-spec.

### DIFF
--- a/context/context.go
+++ b/context/context.go
@@ -129,7 +129,7 @@ func NewContextWD(wdIsRoot bool) (*Context, error) {
 	if err != nil {
 		return nil, err
 	}
-	pathToVendorFile := vendorFilename
+	pathToVendorFile := filepath.Join("vendor", vendorFilename)
 	rootIndicator := "vendor"
 	vendorFolder := "vendor"
 	go15VendorExperiment := os.Getenv("GO15VENDOREXPERIMENT") == "1"

--- a/context/context.go
+++ b/context/context.go
@@ -146,6 +146,12 @@ func NewContextWD(wdIsRoot bool) (*Context, error) {
 		}
 	}
 
+	// Check for old vendor file location.
+	oldLocation := filepath.Join(root, vendorFilename)
+	if _, err := os.Stat(oldLocation); err == nil {
+		return nil, ErrOldVersion{`Use the "migrate" command to update.`}
+	}
+
 	return NewContext(root, pathToVendorFile, vendorFolder, !go15VendorExperiment)
 }
 

--- a/context/context_test.go
+++ b/context/context_test.go
@@ -221,10 +221,24 @@ s strings < ["co2/internal/co3/pk3" "co3/pk3"]
 		}
 		g.Check(c.ModifyImport(item.Local, AddUpdate))
 	}
-
-	c.Reslove(c.Check()) // Automaically resolve conflicts.
+	c.ResloveApply(ResolveAutoLongestPath(c.Check())) // Automaically resolve conflicts.
 	g.Check(c.Alter())
 	g.Check(c.WriteVendorFile())
+	vendorFile14(g, `{
+	"comment": "",
+	"ignore": "",
+	"package": [
+		{
+			"path": "co2/pk2",
+			"revision": ""
+		},
+		{
+			"origin": "co1/internal/co3/pk3",
+			"path": "co3/pk3",
+			"revision": ""
+		}
+	]
+}`)
 
 	expected := `v co1/internal/co2/pk2 [co2/pk2] < ["co1/pk1"]
 v co1/internal/co3/pk3 [co3/pk3] < ["co1/internal/co2/pk2" "co1/pk1"]

--- a/context/context_test.go
+++ b/context/context_test.go
@@ -89,7 +89,7 @@ func showCurrentVendorFile(c *Context, t *testing.T) {
 		if vp.Remove {
 			continue
 		}
-		t.Logf("\tPKG:: C: %s, L: %s\n", vp.Canonical, vp.Local)
+		t.Logf("\tPKG:: P: %s, O: %s\n", vp.Path, vp.Origin)
 	}
 }
 
@@ -143,11 +143,8 @@ func TestImportSimple(t *testing.T) {
 	"ignore": "",
 	"package": [
 		{
-			"canonical": "co2/pk1",
-			"comment": "",
-			"local": "co2/pk1",
-			"revision": "",
-			"revisionTime": ""
+			"path": "co2/pk1",
+			"revision": ""
 		}
 	]
 }`)
@@ -196,11 +193,8 @@ func TestDuplicatePackage(t *testing.T) {
 	"ignore": "",
 	"package": [
 		{
-			"canonical": "co3/pk3",
-			"comment": "",
-			"local": "co3/pk3",
-			"revision": "",
-			"revisionTime": ""
+			"path": "co3/pk3",
+			"revision": ""
 		}
 	]
 }`)
@@ -313,11 +307,8 @@ s strings < ["co1/vendor/co2/pk1" "co2/pk2"]
 	"ignore": "",
 	"package": [
 		{
-			"canonical": "co2/pk1",
-			"comment": "",
-			"local": "vendor/co2/pk1",
-			"revision": "",
-			"revisionTime": ""
+			"path": "co2/pk1",
+			"revision": ""
 		}
 	]
 }`)
@@ -367,18 +358,12 @@ s strings < ["co1/vendor/co2/pk1" "co1/vendor/co2/pk1/pk2"]
 	"ignore": "",
 	"package": [
 		{
-			"canonical": "co2/pk1",
-			"comment": "",
-			"local": "vendor/co2/pk1",
-			"revision": "",
-			"revisionTime": ""
+			"path": "co2/pk1",
+			"revision": ""
 		},
 		{
-			"canonical": "co2/pk1/pk2",
-			"comment": "",
-			"local": "vendor/co2/pk1/pk2",
-			"revision": "",
-			"revisionTime": ""
+			"path": "co2/pk1/pk2",
+			"revision": ""
 		}
 	]
 }`)

--- a/context/err.go
+++ b/context/err.go
@@ -51,3 +51,12 @@ type ErrMissingVendorFile struct {
 func (err ErrMissingVendorFile) Error() string {
 	return fmt.Sprintf("Vendor file at %q not found.", err.Path)
 }
+
+// ErrOldVersion returns if vendor file is not in the vendor folder.
+type ErrOldVersion struct {
+	Message string
+}
+
+func (err ErrOldVersion) Error() string {
+	return fmt.Sprintf("The vendor file or is old. %s", err.Message)
+}

--- a/context/path.go
+++ b/context/path.go
@@ -133,7 +133,7 @@ func (ctx *Context) findCanonicalPath(importPath string) (string, error) {
 	}
 	vpkg := vendorFileFindLocal(vf, root, gopath, importPath)
 	if vpkg != nil {
-		return vpkg.Canonical, nil
+		return vpkg.Path, nil
 	}
 
 	// Vendor file exists, but the package is not a vendor package.
@@ -147,10 +147,11 @@ func vendorFileFindLocal(vf *vendorfile.File, root, gopath, importPath string) *
 		if pkg.Remove {
 			continue
 		}
-		if pkg.Local == local {
+		if pkg.Path == local {
 			return pkg
 		}
 	}
+
 	return nil
 }
 

--- a/context/resolve.go
+++ b/context/resolve.go
@@ -214,7 +214,7 @@ func (ctx *Context) setPackage(dir, canonical, local, gopath string, status Stat
 	if status == StatusUnknown {
 		if vp := ctx.VendorFilePackageLocal(local); vp != nil {
 			status = StatusVendor
-			canonical = vp.Canonical
+			canonical = vp.Path
 		}
 	}
 	if status == StatusUnknown && strings.HasPrefix(canonical, ctx.RootImportPath) {
@@ -290,7 +290,7 @@ func (ctx *Context) determinePackageStatus() error {
 		}
 		if vp := ctx.VendorFilePackageLocal(pkg.Local); vp != nil {
 			pkg.Status = StatusVendor
-			pkg.Canonical = vp.Canonical
+			pkg.Canonical = vp.Path
 			continue
 		}
 		if strings.HasPrefix(pkg.Canonical, ctx.RootImportPath) {
@@ -319,7 +319,7 @@ func (ctx *Context) determinePackageStatus() error {
 		}
 		vpkg := vendorFileFindLocal(vf, root, pkg.Gopath, pkg.Local)
 		if vpkg != nil {
-			pkg.Canonical = vpkg.Canonical
+			pkg.Canonical = vpkg.Path
 		}
 	}
 

--- a/context/vendorFile.go
+++ b/context/vendorFile.go
@@ -15,7 +15,7 @@ import (
 
 // WriteVendorFile writes the current vendor file to the context location.
 func (ctx *Context) WriteVendorFile() (err error) {
-	perm := os.FileMode(0777)
+	perm := os.FileMode(0666)
 	fi, err := os.Stat(ctx.VendorFilePath)
 	if err == nil {
 		perm = fi.Mode()

--- a/context/vendorFile.go
+++ b/context/vendorFile.go
@@ -8,10 +8,8 @@ import (
 	"bytes"
 	"os"
 	"path/filepath"
-	"strings"
 
 	"github.com/kardianos/govendor/internal/github.com/dchest/safefile"
-	"github.com/kardianos/govendor/internal/pathos"
 	"github.com/kardianos/govendor/vendorfile"
 )
 
@@ -49,40 +47,5 @@ func readVendorFile(vendorFilePath string) (*vendorfile.File, error) {
 	if err != nil {
 		return nil, err
 	}
-	// Determine if local field is relative to GOPATH or vendor file.
-	// Change to relative to vendor file as needed.
-	folder, _ := filepath.Split(vendorFilePath)
-	relToFile := 0
-	relToGOPATH := 0
-	for _, pkg := range vf.Package {
-		p := filepath.Join(folder, pathos.SlashToFilepath(pkg.Local))
-		_, err := os.Stat(p)
-		if os.IsNotExist(err) {
-			relToGOPATH++
-			continue
-		}
-		relToFile++
-	}
-	if relToFile > relToGOPATH || len(vf.Package) == 0 {
-		return vf, nil
-	}
-
-	gopathList := strings.Split(os.Getenv("GOPATH"), string(os.PathListSeparator))
-	gopath := ""
-	for _, gp := range gopathList {
-		if pathos.FileHasPrefix(folder, gp) {
-			gopath = gp
-			break
-		}
-	}
-	if len(gopath) == 0 {
-		return vf, nil
-	}
-	prefix := pathos.SlashToImportPath(pathos.FileTrimPrefix(folder, filepath.Join(gopath, "src")))
-	prefix = strings.TrimPrefix(prefix, "/")
-	for _, pkg := range vf.Package {
-		pkg.Local = strings.TrimPrefix(pkg.Local, prefix)
-	}
-
 	return vf, nil
 }

--- a/migrate/migrate.go
+++ b/migrate/migrate.go
@@ -22,10 +22,11 @@ import (
 type From byte
 
 const (
-	Auto     From = iota // Detect which system it uses.
-	Gb                   // Dave's GB
-	Godep                // tools/godep
-	Internal             // kardianos/govendor
+	Auto      From = iota // Detect which system it uses.
+	Gb                    // Dave's GB
+	Godep                 // tools/godep
+	Internal              // kardianos/govendor
+	OldVendor             // old kardianos/govendor
 )
 
 // Migrate from the given system using the current working directory.
@@ -55,10 +56,11 @@ type system interface {
 }
 
 var register = map[From]system{
-	Auto:     sysAuto{},
-	Gb:       sysGb{},
-	Godep:    sysGodep{},
-	Internal: sysInternal{},
+	Auto:      sysAuto{},
+	Gb:        sysGb{},
+	Godep:     sysGodep{},
+	Internal:  sysInternal{},
+	OldVendor: sysOldVendor{},
 }
 
 var errAutoSystemNotFound = errors.New("Unable to determine vendor system.")
@@ -264,6 +266,27 @@ func (sysInternal) Migrate(root string) error {
 		}
 	}
 	return os.Remove(filepath.Join(ctx.RootDir, "internal", "vendor.json"))
+}
+
+type sysOldVendor struct{}
+
+func (sys sysOldVendor) Check(root string) (system, error) {
+	if hasDirs(root, "vendor") && hasFiles(root, "vendor.json") {
+		return sys, nil
+	}
+	return nil, nil
+}
+func (sysOldVendor) Migrate(root string) error {
+	ctx, err := context.NewContext(root, "vendor.json", "vendor", false)
+	if err != nil {
+		return err
+	}
+	ctx.VendorFilePath = filepath.Join(ctx.RootDir, "vendor", "vendor.json")
+	err = ctx.WriteVendorFile()
+	if err != nil {
+		return err
+	}
+	return os.Remove(filepath.Join(ctx.RootDir, "vendor.json"))
 }
 
 func hasDirs(root string, dd ...string) bool {

--- a/migrate/migrate.go
+++ b/migrate/migrate.go
@@ -144,10 +144,7 @@ func (sysGodep) Migrate(root string) error {
 		remove = append(remove, filepath.Join(ctx.RootGopath, filepath.ToSlash(item.Local)))
 		ctx.RewriteRule[item.Local] = item.Canonical
 	}
-	ctx.VendorFilePath = filepath.Join(ctx.RootDir, "vendor.json")
-	for _, vf := range ctx.VendorFile.Package {
-		vf.Local = path.Join("vendor", vf.Canonical)
-	}
+	ctx.VendorFilePath = filepath.Join(ctx.RootDir, "vendor", "vendor.json")
 
 	ctx.VendorDiscoverFolder = "vendor"
 
@@ -183,14 +180,13 @@ func (sysGodep) Migrate(root string) error {
 			if strings.HasPrefix(pkg.Canonical, d.ImportPath) == false {
 				continue
 			}
-			vf := ctx.VendorFilePackageCanonical(pkg.Canonical)
+			vf := ctx.VendorFilePackagePath(pkg.Canonical)
 			if vf == nil {
 				ctx.VendorFile.Package = append(ctx.VendorFile.Package, &vendorfile.Package{
-					Add:       true,
-					Canonical: pkg.Canonical,
-					Local:     path.Join(ctx.VendorDiscoverFolder, pkg.Canonical),
-					Comment:   d.Comment,
-					Revision:  d.Rev,
+					Add:      true,
+					Path:     pkg.Canonical,
+					Comment:  d.Comment,
+					Revision: d.Rev,
 				})
 			}
 		}
@@ -250,10 +246,7 @@ func (sysInternal) Migrate(root string) error {
 		remove = append(remove, filepath.Join(ctx.RootGopath, filepath.ToSlash(item.Local)))
 		ctx.RewriteRule[item.Local] = item.Canonical
 	}
-	ctx.VendorFilePath = filepath.Join(ctx.RootDir, "vendor.json")
-	for _, vf := range ctx.VendorFile.Package {
-		vf.Local = path.Join("vendor", vf.Canonical)
-	}
+	ctx.VendorFilePath = filepath.Join(ctx.RootDir, "vendor", "vendor.json")
 	err = ctx.WriteVendorFile()
 	if err != nil {
 		return err

--- a/run_test.go
+++ b/run_test.go
@@ -80,7 +80,7 @@ e co2/pk1
 e co3/pk1
 l co1/pk1
 `)
-	Vendor(g, "co1 add", "add +ext", "")
+	Vendor(g, "co1 add", "add -long +ext", "")
 	Vendor(g, "co1 list", "list", `v co2/pk1
 v co3/pk1
 l co1/pk1

--- a/vendorfile/file.go
+++ b/vendorfile/file.go
@@ -160,6 +160,9 @@ func (vf *File) toAll() {
 	rawPackageList := vf.getRawPackageList()
 
 	setPkgFields := func(pkg *Package, obj map[string]interface{}) {
+		if pkg.Origin == pkg.Path {
+			pkg.Origin = ""
+		}
 		setObject(pkg.Origin, obj, originNames, true)
 		setObject(pkg.Path, obj, pathNames, false)
 		setObject(pkg.Revision, obj, revisionNames, false)

--- a/vendorfile/file_test.go
+++ b/vendorfile/file_test.go
@@ -27,9 +27,7 @@ func TestUpdate(t *testing.T) {
 	"ignore": "",
 	"package": [
 		{
-			"canonical": "github.com/dchest/safefile",
-			"comment": "",
-			"local": "github.com/kardianos/govendor/internal/github.com/dchest/safefile",
+			"path": "github.com/dchest/safefile",
 			"revision": "74b1ec0619e722c9f674d1a21e1a703fe90c4371",
 			"revisionTime": "2015-04-10T19:48:00+02:00"
 		}
@@ -73,11 +71,8 @@ func TestRemove(t *testing.T) {
 	"ignore": "",
 	"package": [
 		{
-			"canonical": "pkg1",
-			"comment": "",
-			"local": "",
-			"revision": "",
-			"revisionTime": ""
+			"path": "pkg1",
+			"revision": ""
 		}
 	]
 }`
@@ -116,25 +111,16 @@ func TestAdd(t *testing.T) {
 	"ignore": "",
 	"package": [
 		{
-			"canonical": "pkg1",
-			"comment": "",
-			"local": "",
-			"revision": "",
-			"revisionTime": ""
+			"path": "pkg1",
+			"revision": ""
 		},
 		{
-			"canonical": "pkg2",
-			"comment": "",
-			"local": "",
-			"revision": "",
-			"revisionTime": ""
+			"path": "pkg2",
+			"revision": ""
 		},
 		{
-			"canonical": "pkg3",
-			"comment": "",
-			"local": "",
-			"revision": "",
-			"revisionTime": ""
+			"path": "pkg3",
+			"revision": ""
 		}
 	]
 }`
@@ -147,11 +133,11 @@ func TestAdd(t *testing.T) {
 	}
 
 	vf.Package = append(vf.Package, &Package{
-		Add:       true,
-		Canonical: "pkg2",
+		Add:  true,
+		Path: "pkg2",
 	}, &Package{
-		Add:       true,
-		Canonical: "pkg3",
+		Add:  true,
+		Path: "pkg3",
 	})
 
 	buf := &bytes.Buffer{}


### PR DESCRIPTION
The vendor spec has been updated to remove "canonical" and "local" and added "path" and "local".

Also:
Fixes #47
Updates #15