### PR TITLE
Speed improvements for govendor

### DIFF
--- a/context/context.go
+++ b/context/context.go
@@ -287,7 +287,15 @@ func (ctx *Context) VendorFilePackagePath(canonical string) *vendorfile.Package 
 
 // updatePackageReferences populates the referenced field in each Package.
 func (ctx *Context) updatePackageReferences() {
+	canonicalUnderDirLookup := make(map[string]map[string]*Package)
 	findCanonicalUnderDir := func(dir, canonical string) *Package {
+		if importMap, found := canonicalUnderDirLookup[dir]; found {
+			if pkg, found2 := importMap[canonical]; found2 {
+				return pkg
+			}
+		} else {
+			canonicalUnderDirLookup[dir] = make(map[string]*Package)
+		}
 		for _, pkg := range ctx.Package {
 			if !pkg.inVendor {
 				continue
@@ -305,8 +313,10 @@ func (ctx *Context) updatePackageReferences() {
 			if pkg.Canonical != canonical {
 				continue
 			}
+			canonicalUnderDirLookup[dir][canonical] = pkg
 			return pkg
 		}
+		canonicalUnderDirLookup[dir][canonical] = nil
 		return nil
 	}
 	for _, pkg := range ctx.Package {


### PR DESCRIPTION
 - Implement an ast.File cache in context to avoid
   parsing the same files over and over again
 - Context.updatePackageReferences implement
   a cache of directory, canonical import to
   package

Both these improvements took the run time on my source
down from:
time govendor list
...
real	1m28.345s
user	2m5.077s
sys	0m4.551s

To:
time govendor list
...
real	0m3.492s
user	0m4.565s
sys	0m1.144s