### PR TITLE
Context: fix test file detection

### DIFF
--- a/context/resolve.go
+++ b/context/resolve.go
@@ -74,7 +74,7 @@ func (ctx *Context) getFileTags(pathname string, f *ast.File) ([]string, error) 
 	l := strings.Split(filename, "_")
 	tags := make([]string, 0)
 
-	if n := len(l); n > 0 && l[n-1] == "test" {
+	if n := len(l); n > 1 && l[n-1] == "test" {
 		l = l[:n-1]
 		tags = append(tags, "test")
 	}


### PR DESCRIPTION
Hi,

I tried to vendor [`github.com/Sirupsen/logrus`](https://github.com/Sirupsen/logrus) - including the `hooks/test` [subpackage](https://github.com/Sirupsen/logrus/tree/master/hooks/test). Unfortunately, `govendor` ignored the file `test.go` so the vendoring did not work.

This PR adapts `context/resolve.go` to assume that test file names contain at least one `_` character.