### PR TITLE
Fix removal of tabulation character

### DIFF
--- a/pkgspec/pkgspec.go
+++ b/pkgspec/pkgspec.go
@@ -30,7 +30,8 @@ var (
 // package-sepc = <path>[{/...|/^}][::<origin>][@[<version-spec>]]
 func Parse(currentGoPath, s string) (*Pkg, error) {
 	// Clean up the import path before
-	s = strings.Trim(s, `/\ \t`)
+	s = strings.TrimSpace(s)
+	s = strings.Trim(s, `/\`)
 	if len(s) == 0 {
 		return nil, ErrEmptyPath
 	}

--- a/pkgspec/pkgspec_test.go
+++ b/pkgspec/pkgspec_test.go
@@ -26,6 +26,7 @@ func TestParse(t *testing.T) {
 		{Spec: "abc/def@v1.2.3", Pkg: &Pkg{Path: "abc/def", HasVersion: true, Version: "v1.2.3"}},
 		{Spec: "./def@v1.2.3", Str: "abc/def@v1.2.3", Pkg: &Pkg{Path: "abc/def", HasVersion: true, Version: "v1.2.3"}, WD: "abc/"},
 		{Spec: "abc\\def\\", Str: "abc/def", Pkg: &Pkg{Path: "abc/def"}},
+		{Spec: "tab", Pkg: &Pkg{Path: "tab"}},
 	}
 
 	for _, item := range list {


### PR DESCRIPTION
There are multiple ways to fix the issue with cutset:
* Interpreted string instead of raw string
* Valid tab character in the raw string

But in my opinion, a mix of TrimSpace and Trim with raw cutset
looks more robust. One problem at a time...

Before the fix:
```
--- FAIL: TestParse (0.00s)
        pkgspec_test.go:55: For "tab", round tripped to "ab"
```

Fixes #112.