### PR TITLE
Don't remove trailing `t` from a path.

### DIFF
--- a/pkgspec/pkgspec.go
+++ b/pkgspec/pkgspec.go
@@ -30,7 +30,9 @@ var (
 // package-sepc = <path>[{/...|/^}][::<origin>][@[<version-spec>]]
 func Parse(currentGoPath, s string) (*Pkg, error) {
 	// Clean up the import path before
-	s = strings.Trim(s, `/\ \t`)
+	s = strings.TrimSpace(s)
+	s = strings.Trim(s, `/\`)
+
 	if len(s) == 0 {
 		return nil, ErrEmptyPath
 	}

--- a/pkgspec/pkgspec_test.go
+++ b/pkgspec/pkgspec_test.go
@@ -26,6 +26,8 @@ func TestParse(t *testing.T) {
 		{Spec: "abc/def@v1.2.3", Pkg: &Pkg{Path: "abc/def", HasVersion: true, Version: "v1.2.3"}},
 		{Spec: "./def@v1.2.3", Str: "abc/def@v1.2.3", Pkg: &Pkg{Path: "abc/def", HasVersion: true, Version: "v1.2.3"}, WD: "abc/"},
 		{Spec: "abc\\def\\", Str: "abc/def", Pkg: &Pkg{Path: "abc/def"}},
+		{Spec: "client", Str: "client", Pkg: &Pkg{Path: "client"}},
+		{Spec: "  spacey/	", Str: "spacey", Pkg: &Pkg{Path: "spacey"}},
 	}
 
 	for _, item := range list {


### PR DESCRIPTION
Because this was using a raw string for the Trim(), the `\t` was being interpreted as "either a backslash, or the letter `t`. So anything ending in t was getting it stripped off.

e.g

    Error: Failed to fetch package "github.com/aws/aws-sdk-go/aws/client": open /tmp/gopath/.cache/govendor/github.com/aws/aws-sdk-go/aws/clien: no such file or directory

This replaces that part of the trim with a [TrimSpace()](https://golang.org/pkg/strings/#TrimSpace), and then leaves the trim just for slashes.