### PR TITLE
context: make NewContext work with Windows

### DIFF
--- a/context/context.go
+++ b/context/context.go
@@ -12,7 +12,6 @@ import (
 	"io"
 	"os/exec"
 	"path/filepath"
-	"strconv"
 	"strings"
 
 	"github.com/kardianos/govendor/internal/pathos"
@@ -183,15 +182,14 @@ func NewContext(root, vendorFilePathRel, vendorFolder string, rewriteImports boo
 		if err != nil {
 			return nil, err
 		}
-		const gorootLookFor = `GOROOT=`
 		for _, line := range strings.Split(string(goEnv), "\n") {
 			if strings.HasPrefix(line, gorootLookFor) == false {
 				continue
 			}
 			goroot = strings.TrimPrefix(line, gorootLookFor)
-			goroot, err = strconv.Unquote(goroot)
+			goroot, err = gorootFromGoEnv(goroot)
 			if err != nil {
-				return nil, fmt.Errorf("Failed to unquote GOROOT: %v", err)
+				return nil, err
 			}
 			break
 		}

--- a/context/context_other.go
+++ b/context/context_other.go
@@ -1,0 +1,18 @@
+// +build !windows
+
+package context
+
+import (
+	"fmt"
+	"strconv"
+)
+
+const gorootLookFor = `GOROOT=`
+
+func gorootFromGoEnv(s string) (string, error) {
+	goroot, err := strconv.Unquote(s)
+	if err != nil {
+		return "", fmt.Errorf("Failed to unquote GOROOT: %v", err)
+	}
+	return goroot, nil
+}

--- a/context/context_windows.go
+++ b/context/context_windows.go
@@ -1,0 +1,9 @@
+// +build windows
+
+package context
+
+const gorootLookFor = `set GOROOT=`
+
+func gorootFromGoEnv(s string) (string, error) {
+	return s, nil
+}


### PR DESCRIPTION
This PR make NewContext work with Windows.

NewContext assumed that `go env` returned lines in the format `GOROOT="/usr/local/go"` but on Windows it has this format: `set GOROOT=C:/Path`.

This should handle both cases now.