### PR TITLE
fixed error when attempting to copy license files from nested vendor directories

### DIFF
--- a/context/license.go
+++ b/context/license.go
@@ -168,7 +168,9 @@ func licenseCopy(root, startIn, vendorRoot, pkgPath string) error {
 			addTo: "golang.org/x/tools"
 			$PROJ/vendor + addTo + pathos.FileTrimPrefix(folder, root) + "LICENSE"
 		*/
-		destPath := filepath.Join(vendorRoot, addTo, trimTo, name)
+
+		destDir := filepath.Join(vendorRoot, addTo, trimTo)
+		destPath := filepath.Join(destDir, name)
 
 		// Only copy if file does not exist.
 		_, err := os.Stat(destPath)
@@ -176,6 +178,9 @@ func licenseCopy(root, startIn, vendorRoot, pkgPath string) error {
 			return nil
 		}
 
+		if err := os.MkdirAll(destDir, 0777); err != nil {
+			return err
+		}
 		return copyFile(destPath, srcPath, nil)
 	})
 }


### PR DESCRIPTION
Govendor fails to fetch when it attempts to copy license files from a nested vendor directory, as it attempts to create the file before the nested dependency has been copied by govendor. This fix is pretty straightforward in that it simply makes the path in advance, at the time the license is to be copied.  A better fix might be to trigger the license copy at the time of the nested vendor dependency is copied (which it probably already does -- so really it might just be that you need to avoid license copy from following nested vendor directories). In any case, this workaround solves it in a simple way for now. 

To recreate:
```
$ govendor fetch github.com/aws/aws-sdk-go/^
Error: Failed to fetch package "github.com/aws/aws-sdk-go": copy failed. dest:
 "/Development/gopath/src/bar/vendor/github.com/aws/aws-sdk-go", src:
 "/Development/gopath/.cache/govendor/github.com/aws/aws-sdk-go", pkgPath
 "/Development/gopath/.cache/govendor", err open
 /Development/gopath/src/bar/vendor/golang.org/x/tools/LICENSE: no such file or directory
```
