### PR TITLE
quickstart commands for fm/install/test

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,16 @@ govendor fetch golang.org/x/net/context@=v1  # Get the tag or branch named "v1".
 
 # Update a package to latest, given any prior version constraint
 govendor fetch golang.org/x/net/context
+
+# Format your repository only
+govendor fmt +local
+
+# Build everything in your repository only
+govendor install +local
+
+# Test your repository only
+govendor test +local
+
 ```
 
 ## Sub-commands


### PR DESCRIPTION
Add those that ensure people use only vendored copies for fmt/install/test.
That allows developers to get a full Compile-Edit-Run-Cycle using only vendored packages directly from the quickstart.

It took us a day to discover those simple command + argument combinations.