### PR TITLE
context: fix bug with vendoring package trees with same prefix

### DIFF
--- a/context/context.go
+++ b/context/context.go
@@ -286,7 +286,7 @@ func (ctx *Context) findPackageChild(ck *Package) []*Package {
 		if pkg.Status.Presence == PresenceTree {
 			continue
 		}
-		if strings.HasPrefix(pkg.Path, ck.Path) {
+		if strings.HasPrefix(pkg.Path, ck.Path+"/") {
 			out = append(out, pkg)
 		}
 	}
@@ -306,7 +306,7 @@ func (ctx *Context) findPackageParentTree(ck *Package) []string {
 		}
 		// pkg.Path = github.com/usera/pkg, tree = true
 		// ck.Path = github.com/usera/pkg/dance
-		if strings.HasPrefix(ck.Path, pkg.Path) {
+		if strings.HasPrefix(ck.Path, pkg.Path+"/") {
 			out = append(out, pkg.Local)
 		}
 	}

--- a/context/context_test.go
+++ b/context/context_test.go
@@ -1372,3 +1372,45 @@ func TestRelativePath(t *testing.T) {
  s  strings < ["co2/pk1"]
 `)
 }
+
+func TestAddTreeWithSamePrefix(t *testing.T) {
+	g := gt.New(t)
+	defer g.Clean()
+
+	g.Setup("co1/pk1",
+		gt.File("a.go"),
+	)
+	g.Setup("co2/pk1",
+		gt.File("a.go"),
+	)
+	g.Setup("co2/pk1-1",
+		gt.File("a.go"),
+	)
+	g.In("co1")
+	c := ctx(g)
+	g.Check(c.ModifyImport(pkg("co2/pk1"), Add, IncludeTree))
+	g.Check(c.Alter())
+	g.Check(c.ModifyImport(pkg("co2/pk1-1"), Add, IncludeTree))
+	g.Check(c.Alter())
+}
+
+func TestAddTreeWithSamePrefix2(t *testing.T) {
+	g := gt.New(t)
+	defer g.Clean()
+
+	g.Setup("co1/pk1",
+		gt.File("a.go"),
+	)
+	g.Setup("co2/pk1",
+		gt.File("a.go"),
+	)
+	g.Setup("co2/pk1-1",
+		gt.File("a.go"),
+	)
+	g.In("co1")
+	c := ctx(g)
+	g.Check(c.ModifyImport(pkg("co2/pk1-1"), Add, IncludeTree))
+	g.Check(c.Alter())
+	g.Check(c.ModifyImport(pkg("co2/pk1"), Add, IncludeTree))
+	g.Check(c.Alter())
+}


### PR DESCRIPTION
PR fixes following situation:
```
% govendor init
% govendor fetch github.com/dgryski/go-bits/^
% govendor fetch github.com/dgryski/go-bitstream
Error: Cannot add package "github.com/dgryski/go-bitstream" which is already found in sub-tree ["test/vendor/github.com/dgryski/go-bits"]
% rm -rf vendor/
% govendor init
% govendor fetch github.com/dgryski/go-bitstream/^
% govendor fetch github.com/dgryski/go-bits/^
Error: Cannot have a sub-tree "github.com/dgryski/go-bits" contain sub-packages ["test/vendor/github.com/dgryski/go-bitstream"]
```