### PR TITLE
Exclude packages in vendor.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ govendor test +local
 	license  List discovered licenses for the given status or import paths.
 	shell    Run a "shell" to make multiple sub-commands more efficent for large
 	             projects.
-	
+
 	go tool commands that are wrapped:
 	  `+<status>` package selection may be used with them
 	fmt, build, install, clean, test, vet, generate
@@ -90,6 +90,7 @@ Packages can be specified by their "status".
 	+vendor   (v) packages in the vendor folder
 	+std      (s) packages in the standard library
 
+	+excluded (x) external packages explicitely excluded from vendoring
 	+unused   (u) packages in the vendor folder, but unused
 	+missing  (m) referenced packages but not found
 
@@ -103,7 +104,8 @@ Status can be referenced by their initial letters.
 
  * `+std` same as `+s`
  * `+external` same as `+ext` same as `+e`
-	
+ * `+excluded` same as `+exc` same as `+x`
+
 Status can be logically composed:
 
  * `+local,program` (local AND program) local packages that are also programs
@@ -114,7 +116,7 @@ Status can be logically composed:
 
 ## Package specifier
 
-The full package-spec is: 
+The full package-spec is:
 `<path>[::<origin>][{/...|/^}][@[<version-spec>]]`
 
 Some examples:
@@ -146,7 +148,7 @@ Commands that accept status and package-spec:
 You may pass arguments to govendor through stdin if the last argument is a "-".
 For example `echo +vendor | govendor list -` will list all vendor packages.
 
-## Ignoring build tags
+## Ignoring build tags and excluding packages
 Ignoring build tags is opt-out and is designed to be the opposite of the build
 file directives which are opt-in when specified. Typically a developer will
 want to support cross platform builds, but selectively opt out of tags, tests,
@@ -158,5 +160,21 @@ For example the following will ignore both test and appengine files.
 ```
 {
 	"ignore": "test appengine",
+}
+```
+
+Similarly, some specific packages can be excluded from the vendoring process.
+These packages will be listed as `excluded` (`x`), and will not be copied to the
+"vendor" folder when running `govendor add|fetch|update`.
+
+Any sub-package `foo/bar` of an excluded package `foo` is also excluded (but
+package `bar/foo` is not). The import dependencies of excluded packages are not
+listed, and thus not vendored.
+
+To exclude packages, also use the "ignore" field of the "vendor.json" file.
+Packages are identified by their name followed by a trailing "/":
+```
+{
+	"ignore": "test appengine foo/",
 }
 ```

--- a/README.md
+++ b/README.md
@@ -172,7 +172,8 @@ package `bar/foo` is not). The import dependencies of excluded packages are not
 listed, and thus not vendored.
 
 To exclude packages, also use the "ignore" field of the "vendor.json" file.
-Packages are identified by their name followed by a trailing "/":
+Packages are identified by their name, they should contain a "/" character
+(possibly at the end):
 ```
 {
 	"ignore": "test appengine foo/",

--- a/context/context.go
+++ b/context/context.go
@@ -65,7 +65,8 @@ type Context struct {
 	loaded, dirty  bool
 	rewriteImports bool
 
-	ignoreTag []string // list of tags to ignore
+	ignoreTag      []string // list of tags to ignore
+	excludePackage []string // list of package prefixes to exclude
 
 	statusCache []StatusItem
 	added       map[string]bool
@@ -233,6 +234,7 @@ func NewContext(root, vendorFilePathRel, vendorFolder string, rewriteImports boo
 	}
 
 	ctx.IgnoreBuild(vf.Ignore)
+	ctx.ExcludePackage(vf.Exclude)
 
 	return ctx, nil
 }
@@ -248,6 +250,20 @@ func (ctx *Context) IgnoreBuild(ignore string) {
 			continue
 		}
 		ctx.ignoreTag = append(ctx.ignoreTag, or)
+	}
+}
+
+// ExcludePackage takes a space separated list of package prefixes to ignore.
+// "a b" will ignore "a" OR "b" OR "a/c", etc.
+func (ctx *Context) ExcludePackage(exclude string) {
+	ctx.dirty = true
+	ors := strings.Fields(exclude)
+	ctx.excludePackage = make([]string, 0, len(ors))
+	for _, or := range ors {
+		if len(or) == 0 {
+			continue
+		}
+		ctx.excludePackage = append(ctx.excludePackage, strings.Trim(or, "./"))
 	}
 }
 

--- a/context/context.go
+++ b/context/context.go
@@ -240,9 +240,9 @@ func NewContext(root, vendorFilePathRel, vendorFolder string, rewriteImports boo
 
 // IgnoreBuildAndPackage takes a space separated list of tags or package prefixes
 // to ignore.
-// Tags are words, packages are folders, ending with a "/".
+// Tags are words, packages are folders, containing or ending with a "/".
 // "a b c" will ignore tags "a" OR "b" OR "c".
-// "p/ q/" will ignore packages "p" OR "q" OR "p/x", etc.
+// "p/x q/" will ignore packages "p/x" OR "p/x/y" OR "q" OR "q/z", etc.
 func (ctx *Context) IgnoreBuildAndPackage(ignore string) {
 	ctx.dirty = true
 	ors := strings.Fields(ignore)
@@ -252,7 +252,7 @@ func (ctx *Context) IgnoreBuildAndPackage(ignore string) {
 		if len(or) == 0 {
 			continue
 		}
-		if or[len(or)-1] == '/' {
+		if strings.Index(or, "/") != -1 {
 			// package
 			ctx.excludePackage = append(ctx.excludePackage, strings.Trim(or, "./"))
 		} else {

--- a/context/context.go
+++ b/context/context.go
@@ -79,7 +79,7 @@ type Package struct {
 	Status Status // Status and location of the package.
 	*pkgspec.Pkg
 	Local  string // Current location of a package relative to $GOPATH/src.
-	Gopath string // Inlcudes trailing "src".
+	Gopath string // Includes trailing "src".
 	Files  []*File
 
 	inVendor bool // Different then Status.Location, this is in *any* vendor tree.
@@ -259,7 +259,7 @@ func (ctx *Context) Write(s []byte) (int, error) {
 	return len(s), nil
 }
 
-// VendorFilePackageCanonical finds a given vendor file package give the import path.
+// VendorFilePackagePath finds a given vendor file package give the import path.
 func (ctx *Context) VendorFilePackagePath(path string) *vendorfile.Package {
 	for _, pkg := range ctx.VendorFile.Package {
 		if pkg.Remove {

--- a/context/context.go
+++ b/context/context.go
@@ -233,37 +233,32 @@ func NewContext(root, vendorFilePathRel, vendorFolder string, rewriteImports boo
 		return nil, err
 	}
 
-	ctx.IgnoreBuild(vf.Ignore)
-	ctx.ExcludePackage(vf.Exclude)
+	ctx.IgnoreBuildAndPackage(vf.Ignore)
 
 	return ctx, nil
 }
 
-// IgnoreBuild takes a space separated list of tags to ignore.
-// "a b c" will ignore "a" OR "b" OR "c".
-func (ctx *Context) IgnoreBuild(ignore string) {
+// IgnoreBuildAndPackage takes a space separated list of tags or package prefixes
+// to ignore.
+// Tags are words, packages are folders, ending with a "/".
+// "a b c" will ignore tags "a" OR "b" OR "c".
+// "p/ q/" will ignore packages "p" OR "q" OR "p/x", etc.
+func (ctx *Context) IgnoreBuildAndPackage(ignore string) {
 	ctx.dirty = true
 	ors := strings.Fields(ignore)
 	ctx.ignoreTag = make([]string, 0, len(ors))
-	for _, or := range ors {
-		if len(or) == 0 {
-			continue
-		}
-		ctx.ignoreTag = append(ctx.ignoreTag, or)
-	}
-}
-
-// ExcludePackage takes a space separated list of package prefixes to ignore.
-// "a b" will ignore "a" OR "b" OR "a/c", etc.
-func (ctx *Context) ExcludePackage(exclude string) {
-	ctx.dirty = true
-	ors := strings.Fields(exclude)
 	ctx.excludePackage = make([]string, 0, len(ors))
 	for _, or := range ors {
 		if len(or) == 0 {
 			continue
 		}
-		ctx.excludePackage = append(ctx.excludePackage, strings.Trim(or, "./"))
+		if or[len(or)-1] == '/' {
+			// package
+			ctx.excludePackage = append(ctx.excludePackage, strings.Trim(or, "./"))
+		} else {
+			// tag
+			ctx.ignoreTag = append(ctx.ignoreTag, or)
+		}
 	}
 }
 

--- a/context/context_test.go
+++ b/context/context_test.go
@@ -465,7 +465,7 @@ pv  co1/vendor/co2/pk1 [co2/pk1] < []
  s  testing < ["co1/vendor/co2/pk1"]
 `)
 
-	c.IgnoreBuild("test")
+	c.IgnoreBuildAndPackage("test")
 
 	list(g, c, "ignore test", `
 pv  co1/vendor/co2/pk1 [co2/pk1] < []
@@ -936,7 +936,7 @@ func TestTagList(t *testing.T) {
  s  encoding/json < ["co2/pk1"]
  s  testing < ["co1/pk1" "co2/pk1"]
 `)
-	c.IgnoreBuild("test appengine")
+	c.IgnoreBuildAndPackage("test appengine")
 
 	list(g, c, "co1 list", `
  e  co2/pk1 < ["co1/pk1"]
@@ -947,7 +947,7 @@ func TestTagList(t *testing.T) {
  s  testing < ["co1/pk1"]
 `)
 
-	c.IgnoreBuild("")
+	c.IgnoreBuildAndPackage("")
 
 	g.Check(c.ModifyStatus(StatusGroup{
 		Status: []Status{{Location: LocationExternal}},
@@ -964,7 +964,7 @@ func TestTagList(t *testing.T) {
  s  encoding/json < ["co1/vendor/co2/pk1"]
  s  testing < ["co1/pk1" "co1/vendor/co2/pk1"]
 `)
-	c.IgnoreBuild("test appengine")
+	c.IgnoreBuildAndPackage("test appengine")
 
 	list(g, c, "after co1 list", `
  v  co1/vendor/co2/pk1 [co2/pk1] < ["co1/pk1"]
@@ -994,7 +994,7 @@ func TestTagAdd(t *testing.T) {
 	)
 	g.In("co1")
 	c := ctx(g)
-	c.IgnoreBuild("test appengine")
+	c.IgnoreBuildAndPackage("test appengine")
 
 	g.Check(c.ModifyImport(pkg("co2/pk1"), Add))
 	g.Check(c.Alter())

--- a/context/modify.go
+++ b/context/modify.go
@@ -129,6 +129,10 @@ statusLoop:
 		if ctx.added[item.Pkg.PathOrigin()] {
 			continue
 		}
+		// Do not add excluded packages
+		if item.Status.Presence == PresenceExcluded {
+			continue
+		}
 		// Do not attempt to add any existing status items that are
 		// already present in vendor folder.
 		if mod == Add {

--- a/context/resolve.go
+++ b/context/resolve.go
@@ -481,14 +481,14 @@ func (ctx *Context) determinePackageStatus() error {
 	for i := 0; i <= looplimit; i++ {
 		altered := false
 		for path, pkg := range ctx.Package {
-			if pkg.Status.Presence == PresenceUnsued || pkg.Status.Presence == PresenceTree || pkg.Status.Type == TypeProgram {
+			if pkg.Status.Presence == PresenceUnused || pkg.Status.Presence == PresenceTree || pkg.Status.Type == TypeProgram {
 				continue
 			}
 			if len(pkg.referenced) > 0 || pkg.Status.Location != LocationVendor {
 				continue
 			}
 			altered = true
-			pkg.Status.Presence = PresenceUnsued
+			pkg.Status.Presence = PresenceUnused
 			for _, other := range ctx.Package {
 				delete(other.referenced, path)
 			}
@@ -513,7 +513,7 @@ func (ctx *Context) determinePackageStatus() error {
 			}
 			altered = true
 			delete(ctx.Package, path)
-			pkg.Status.Presence = PresenceUnsued
+			pkg.Status.Presence = PresenceUnused
 			for _, other := range ctx.Package {
 				delete(other.referenced, path)
 			}

--- a/context/status.go
+++ b/context/status.go
@@ -17,7 +17,7 @@ type (
 	Status struct {
 		Type     StatusType     // program, package
 		Location StatusLocation // vendor, local, external, stdlib
-		Presence StatusPresence // missing, unused, tree
+		Presence StatusPresence // missing, unused, tree, excluded
 
 		Not bool // Not indicates boolean operation "not" on above.
 	}
@@ -82,6 +82,8 @@ func (s Status) String() string {
 		p = 'u'
 	case PresenceTree:
 		p = 't'
+	case PresenceExcluded:
+		p = 'x'
 	}
 	return not + string(t) + string(l) + string(p)
 }
@@ -168,11 +170,12 @@ const (
 )
 
 const (
-	PresenceUnknown StatusPresence = iota // PresenceUnknown is unset StatusPresence.
-	PresenceFound                         // PresenceFound package exists.
-	PresenceMissing                       // PresenceMissing package is referenced but not found.
-	PresenceUnused                        // PresenceUnused package is found locally but not referenced.
-	PresenceTree                          // PresenceTree package is in vendor folder, in a tree, but not referenced.
+	PresenceUnknown  StatusPresence = iota // PresenceUnknown is unset StatusPresence.
+	PresenceFound                          // PresenceFound package exists.
+	PresenceMissing                        // PresenceMissing package is referenced but not found.
+	PresenceUnused                         // PresenceUnused package is found locally but not referenced.
+	PresenceTree                           // PresenceTree package is in vendor folder, in a tree, but not referenced.
+	PresenceExcluded                       // PresenceExcluded package exists, but should not be vendored.
 )
 
 // ListItem represents a package in the current project.

--- a/context/status.go
+++ b/context/status.go
@@ -78,7 +78,7 @@ func (s Status) String() string {
 		p = ' '
 	case PresenceMissing:
 		p = 'm'
-	case PresenceUnsued:
+	case PresenceUnused:
 		p = 'u'
 	case PresenceTree:
 		p = 't'
@@ -171,7 +171,7 @@ const (
 	PresenceUnknown StatusPresence = iota // PresenceUnknown is unset StatusPresence.
 	PresenceFound                         // PresenceFound package exists.
 	PresenceMissing                       // PresenceMissing package is referenced but not found.
-	PresenceUnsued                        // PresenceUnused package is found locally but not referenced.
+	PresenceUnused                        // PresenceUnused package is found locally but not referenced.
 	PresenceTree                          // PresenceTree package is in vendor folder, in a tree, but not referenced.
 )
 

--- a/help/text.go
+++ b/help/text.go
@@ -62,10 +62,10 @@ Ignoring files with build tags, or excluding packages from being vendored:
 	The "vendor.json" file contains a string field named "ignore".
 	It may contain a space separated list of build tags to ignore when
 	listing and copying files.
-	This list may also contain package prefixes (ending with a "/") to exclude
-	when copying files in the vendor folder. If "foo/" appears in this field,
-	then package "foo" and all its sub-packages ("foo/bar", …) will be excluded
-	(but package "bar/foo" will not).
+	This list may also contain package prefixes (containing a "/", possibly
+	as last character) to exclude when copying files in the vendor folder.
+	If "foo/" appears in this field, then package "foo" and all its sub-packages
+	("foo/bar", …) will be excluded (but package "bar/foo" will not).
 	By default the init command adds the "test" tag to the ignore list.
 
 If using go1.5, ensure GO15VENDOREXPERIMENT=1 is set.

--- a/help/text.go
+++ b/help/text.go
@@ -44,7 +44,7 @@ Status Types
 	+vendor   (v) packages in the vendor folder
 	+std      (s) packages in the standard library
 
-	+excluded (x) referenced packages explicitely excluded from vendoring
+	+excluded (x) external packages explicitely excluded from vendoring
 	+unused   (u) packages in the vendor folder, but unused
 	+missing  (m) referenced packages but not found
 
@@ -58,19 +58,15 @@ Status Types
 Package specifier
 	<path>[::<origin>][{/...|/^}][@[<version-spec>]]
 
-Ignoring files with build tags:
+Ignoring files with build tags, or excluding packages from being vendored:
 	The "vendor.json" file contains a string field named "ignore".
 	It may contain a space separated list of build tags to ignore when
-	listing and copying files. By default the init command adds the
-	the "test" tag to the ignore list.
-
-Excluding packages from being vendored:
-	The "vendor.json" file contains a string field named "exclude".
-	It may contain a space separated list of package prefixes to exclude
-	when copying files in the vendor folder.
-	If "foo" appears in this field, then package "foo" and all its
-	sub-packages ("foo/bar", …) will be excluded, but package "bar/foo"
-	will not.
+	listing and copying files.
+	This list may also contain package prefixes (ending with a "/") to exclude
+	when copying files in the vendor folder. If "foo/" appears in this field,
+	then package "foo" and all its sub-packages ("foo/bar", …) will be excluded
+	(but package "bar/foo" will not).
+	By default the init command adds the "test" tag to the ignore list.
 
 If using go1.5, ensure GO15VENDOREXPERIMENT=1 is set.
 

--- a/help/text.go
+++ b/help/text.go
@@ -32,18 +32,19 @@ Sub-Commands
 	license  List discovered licenses for the given status or import paths.
 	shell    Run a "shell" to make multiple sub-commands more efficent for large
 	             projects.
-	
+
 	go tool commands that are wrapped:
 	  "+status" package selection may be used with them
 	fmt, build, install, clean, test, vet, generate
 
-Status Types	
+Status Types
 
 	+local    (l) packages in your project
 	+external (e) referenced packages in GOPATH but not in current project
 	+vendor   (v) packages in the vendor folder
 	+std      (s) packages in the standard library
 
+	+excluded (x) referenced packages explicitely excluded from vendoring
 	+unused   (u) packages in the vendor folder, but unused
 	+missing  (m) referenced packages but not found
 
@@ -51,10 +52,10 @@ Status Types
 
 	+outside  +external +missing
 	+all      +all packages
-	
+
 	Status can be referenced by their initial letters.
-	
-Package specifier 
+
+Package specifier
 	<path>[::<origin>][{/...|/^}][@[<version-spec>]]
 
 Ignoring files with build tags:
@@ -62,6 +63,14 @@ Ignoring files with build tags:
 	It may contain a space separated list of build tags to ignore when
 	listing and copying files. By default the init command adds the
 	the "test" tag to the ignore list.
+
+Excluding packages from being vendored:
+	The "vendor.json" file contains a string field named "exclude".
+	It may contain a space separated list of package prefixes to exclude
+	when copying files in the vendor folder.
+	If "foo" appears in this field, then package "foo" and all its
+	sub-packages ("foo/bar", …) will be excluded, but package "bar/foo"
+	will not.
 
 If using go1.5, ensure GO15VENDOREXPERIMENT=1 is set.
 
@@ -88,11 +97,11 @@ var helpAdd = `govendor add [options] ( +status or import-path-filter )
 	Options:
 		-n           dry run and print actions that would be taken
 		-tree        copy package(s) and all sub-folders under each package
-		-uncommitted allows copying a package with uncommitted changes, doesn't 
+		-uncommitted allows copying a package with uncommitted changes, doesn't
 		             update revision or checksum so it will always be out-of-date.
-		
+
 		The following may be replaced with something else in the future.
-		-short       if conflict, take short path 
+		-short       if conflict, take short path
 		-long        if conflict, take long path
 `
 
@@ -101,11 +110,11 @@ var helpUpdate = `govendor update [options] ( +status or import-path-filter )
 	Options:
 		-n           dry run and print actions that would be taken
 		-tree        copy package(s) and all sub-folders under each package
-		-uncommitted allows copying a package with uncommitted changes, doesn't 
+		-uncommitted allows copying a package with uncommitted changes, doesn't
 		             update revision or checksum so it will always be out-of-date.
-		
+
 		The following may be replaced with something else in the future.
-		-short       if conflict, take short path 
+		-short       if conflict, take short path
 		-long        if conflict, take long path
 `
 

--- a/run/filter.go
+++ b/run/filter.go
@@ -63,7 +63,7 @@ func parseStatusGroup(statusString string) (sg context.StatusGroup, err error) {
 		case strings.HasPrefix("vendor", s):
 			st.Location = context.LocationVendor
 		case strings.HasPrefix("unused", s):
-			st.Presence = context.PresenceUnsued
+			st.Presence = context.PresenceUnused
 		case strings.HasPrefix("missing", s):
 			st.Presence = context.PresenceMissing
 		case strings.HasPrefix("local", s):

--- a/run/filter.go
+++ b/run/filter.go
@@ -66,6 +66,10 @@ func parseStatusGroup(statusString string) (sg context.StatusGroup, err error) {
 			st.Presence = context.PresenceUnused
 		case strings.HasPrefix("missing", s):
 			st.Presence = context.PresenceMissing
+		case strings.HasPrefix("xcluded", s):
+			st.Presence = context.PresenceExcluded
+		case len(s) >= 3 && strings.HasPrefix("excluded", s): // len >= 3 to distinguish from "external"
+			st.Presence = context.PresenceExcluded
 		case strings.HasPrefix("local", s):
 			st.Location = context.LocationLocal
 		case strings.HasPrefix("program", s):

--- a/vendorfile/file.go
+++ b/vendorfile/file.go
@@ -27,6 +27,8 @@ type File struct {
 
 	Ignore string
 
+	Exclude string
+
 	Package []*Package
 
 	// all preserves unknown values.
@@ -98,6 +100,7 @@ var (
 	rootPathNames     = []string{"rootPath"}
 	packageNames      = []string{"package", "Package"}
 	ignoreNames       = []string{"ignore"}
+	excludeNames      = []string{"exclude"}
 	originNames       = []string{"origin"}
 	pathNames         = []string{"path", "canonical", "Canonical", "vendor", "Vendor"}
 	treeNames         = []string{"tree"}
@@ -208,6 +211,7 @@ func (vf *File) toFields() {
 	setField(&vf.RootPath, vf.all, rootPathNames)
 	setField(&vf.Comment, vf.all, commentNames)
 	setField(&vf.Ignore, vf.all, ignoreNames)
+	setField(&vf.Exclude, vf.all, excludeNames)
 
 	rawPackageList := vf.getRawPackageList()
 
@@ -240,6 +244,7 @@ func (vf *File) toAll() {
 	setObject(vf.RootPath, vf.all, rootPathNames, true)
 	setObject(vf.Comment, vf.all, commentNames, false)
 	setObject(vf.Ignore, vf.all, ignoreNames, false)
+	setObject(vf.Exclude, vf.all, excludeNames, false)
 
 	rawPackageList := vf.getRawPackageList()
 

--- a/vendorfile/file.go
+++ b/vendorfile/file.go
@@ -27,8 +27,6 @@ type File struct {
 
 	Ignore string
 
-	Exclude string
-
 	Package []*Package
 
 	// all preserves unknown values.
@@ -100,7 +98,6 @@ var (
 	rootPathNames     = []string{"rootPath"}
 	packageNames      = []string{"package", "Package"}
 	ignoreNames       = []string{"ignore"}
-	excludeNames      = []string{"exclude"}
 	originNames       = []string{"origin"}
 	pathNames         = []string{"path", "canonical", "Canonical", "vendor", "Vendor"}
 	treeNames         = []string{"tree"}
@@ -211,7 +208,6 @@ func (vf *File) toFields() {
 	setField(&vf.RootPath, vf.all, rootPathNames)
 	setField(&vf.Comment, vf.all, commentNames)
 	setField(&vf.Ignore, vf.all, ignoreNames)
-	setField(&vf.Exclude, vf.all, excludeNames)
 
 	rawPackageList := vf.getRawPackageList()
 
@@ -244,7 +240,6 @@ func (vf *File) toAll() {
 	setObject(vf.RootPath, vf.all, rootPathNames, true)
 	setObject(vf.Comment, vf.all, commentNames, false)
 	setObject(vf.Ignore, vf.all, ignoreNames, false)
-	setObject(vf.Exclude, vf.all, excludeNames, false)
 
 	rawPackageList := vf.getRawPackageList()
 


### PR DESCRIPTION
This feature enables the `vendor.json` file to contain an `exclude` attribute, containing a space-separated set of package prefixes which should be excluded from vendoring.

For example, if `vendor.json` contains `exclude: "foo"`, then `govendor list` will show that packages `foo` (exact match) and `foo/bar` (sub-package) are external dependencies, but are excluded from vendoring. Package `bar/foo`, on the opposite, is not excluded.
Packages imported only by excluded packages are not listed.

When running `govendor add|update|fetch`, excluded packages are ignored and not copied into the vendor folder.

This solves issue #156 