### PR TITLE
Fix packages being mistakenly seen as local when the root path is a prefix

### DIFF
--- a/context/resolve.go
+++ b/context/resolve.go
@@ -310,7 +310,7 @@ func (ctx *Context) setPackage(dir, canonical, local, gopath string, status Stat
 			originDir = od
 		}
 	}
-	if status.Location == LocationUnknown && strings.HasPrefix(canonical, ctx.RootImportPath) {
+	if status.Location == LocationUnknown && filepath.HasPrefixDir(canonical, ctx.RootImportPath) {
 		status.Location = LocationLocal
 	}
 	spec, err := pkgspec.Parse("", canonical)
@@ -433,7 +433,7 @@ func (ctx *Context) determinePackageStatus() error {
 		if pkg.Status.Location != LocationUnknown {
 			continue
 		}
-		if strings.HasPrefix(pkg.Path, ctx.RootImportPath) {
+		if filepath.HasPrefixDir(pkg.Path, ctx.RootImportPath) {
 			pkg.Status.Location = LocationLocal
 			continue
 		}

--- a/internal/vfilepath/prefix.go
+++ b/internal/vfilepath/prefix.go
@@ -5,6 +5,13 @@ import (
 	"strings"
 )
 
-func HasPrefixDir(file string, prefix string) bool {
-	return strings.HasPrefix(filepath.Clean(file), filepath.Clean(prefix)+"/")
+func HasPrefixDir(path string, prefix string) bool {
+	return strings.HasPrefix(makeDirPath(path), makeDirPath(prefix))
+}
+
+func makeDirPath(path string) string {
+	if path = filepath.Clean(path); path != "/" {
+		path += "/"
+	}
+	return path
 }

--- a/internal/vfilepath/prefix.go
+++ b/internal/vfilepath/prefix.go
@@ -1,0 +1,10 @@
+package vfilepath
+
+import (
+	"path/filepath"
+	"strings"
+)
+
+func HasPrefixDir(file string, prefix string) bool {
+	return strings.HasPrefix(filepath.Clean(file), filepath.Clean(prefix)+"/")
+}

--- a/internal/vfilepath/prefix_test.go
+++ b/internal/vfilepath/prefix_test.go
@@ -1,0 +1,59 @@
+package vfilepath
+
+import "testing"
+
+func TestHasPrefixDirTrue(t *testing.T) {
+	tests := []struct {
+		path   string
+		prefix string
+	}{
+		{
+			path:   "/",
+			prefix: "/",
+		},
+		{
+			path:   "/foo",
+			prefix: "/",
+		},
+		{
+			path:   "/foo",
+			prefix: "/foo",
+		},
+		{
+			path:   "/foo/bar",
+			prefix: "/foo",
+		},
+		{
+			path:   "foo/bar",
+			prefix: "foo",
+		},
+	}
+
+	for _, test := range tests {
+		if !HasPrefixDir(test.path, test.prefix) {
+			t.Errorf("%s should have %s as prefix", test.path, test.prefix)
+		}
+	}
+}
+
+func TestHasPrefixDirFalse(t *testing.T) {
+	tests := []struct {
+		path   string
+		prefix string
+	}{
+		{
+			path:   "/",
+			prefix: "/foo",
+		},
+		{
+			path:   "/foo-bar",
+			prefix: "/foo",
+		},
+	}
+
+	for _, test := range tests {
+		if HasPrefixDir(test.path, test.prefix) {
+			t.Errorf("%s should not have %s as prefix", test.path, test.prefix)
+		}
+	}
+}


### PR DESCRIPTION
Fixes https://github.com/kardianos/govendor/issues/194

Before:
```
$ govendor list +local
pl  github.com/segmentio/ecs-logs
 l  github.com/segmentio/ecs-logs-go
 l  github.com/segmentio/ecs-logs-go/apex
 l  github.com/segmentio/ecs-logs/lib
 l  github.com/segmentio/ecs-logs/lib/cloudwatchlogs
 l  github.com/segmentio/ecs-logs/lib/datadog
 l  github.com/segmentio/ecs-logs/lib/journald
 l  github.com/segmentio/ecs-logs/lib/loggly
 l  github.com/segmentio/ecs-logs/lib/statsd
 l  github.com/segmentio/ecs-logs/lib/syslog
```

After:
```
$ govendor list +local
pl  github.com/segmentio/ecs-logs
 l  github.com/segmentio/ecs-logs/lib
 l  github.com/segmentio/ecs-logs/lib/cloudwatchlogs
 l  github.com/segmentio/ecs-logs/lib/datadog
 l  github.com/segmentio/ecs-logs/lib/journald
 l  github.com/segmentio/ecs-logs/lib/loggly
 l  github.com/segmentio/ecs-logs/lib/statsd
 l  github.com/segmentio/ecs-logs/lib/syslog
```

Please let me know if you want to see anything changed.