### PR TITLE
[fixup] filepath.Walk didn't follow symlink

### DIFF
--- a/internal/vfilepath/stub.go
+++ b/internal/vfilepath/stub.go
@@ -11,3 +11,7 @@ func Split(path string) (string, string) {
 func Join(parts ...string) string {
 	return filepath.Join(parts...)
 }
+
+func EvalSymlinks(path string) (string, error) {
+	return filepath.EvalSymlinks(path)
+}


### PR DESCRIPTION
Prior this patch govendor didn't have the same behavior that other go tools, like go build, GoDeps, ...
This patch fix this issue, by following only the root package transparently.

Test scenario :

 ls github.com/kardianos
 govendor -> govendor.real/
 cd github.com/kardianos/govendor
 govendor list