### PR TITLE
context: do not ignore dotfiles when copying trees

### DIFF
--- a/context/copy.go
+++ b/context/copy.go
@@ -100,7 +100,7 @@ func (ctx *Context) CopyPackage(destPath, srcPath, lookRoot, pkgPath string, ign
 fileLoop:
 	for _, fi := range fl {
 		name := fi.Name()
-		if name[0] == '.' {
+		if !tree && name[0] == '.' {
 			continue
 		}
 		if fi.IsDir() {


### PR DESCRIPTION
Some npm build scripts use dotfiles.
Grafana for example requires .jscs.json to be present,
when running npm run build.