### PR TITLE
fixes several test failures on Windows

### DIFF
--- a/internal/vfilepath/prefix.go
+++ b/internal/vfilepath/prefix.go
@@ -1,16 +1,13 @@
 package vfilepath
 
-import (
-	"path/filepath"
-	"strings"
-)
+import "strings"
 
 func HasPrefixDir(path string, prefix string) bool {
 	return strings.HasPrefix(makeDirPath(path), makeDirPath(prefix))
 }
 
 func makeDirPath(path string) string {
-	if path = filepath.Clean(path); path != "/" {
+	if path != "/" {
 		path += "/"
 	}
 	return path


### PR DESCRIPTION
This change makes the following tests pass on Windows. Also fixes #209 

```
--- FAIL: TestSimple (0.05s)
	context_test.go:51: A: s  bytes < []
		B: e  co2/pk1 < ["co1/pk1"]
		(initial) Got
		 s  bytes < []
		 s  strings < []
--- FAIL: TestTest (0.13s)
	context_test.go:51: A: v  co1/vendor/co2/pk1 [co2/pk1] < []
		B: v  co1/vendor/co2/pk1 [co2/pk1] < ["co1/pk1"]
		(after) Got
		 v  co1/vendor/co2/pk1 [co2/pk1] < []
		 s  bytes < ["co1/vendor/co2/pk1"]
		 s  strings < ["co1/vendor/co2/pk1"]
--- FAIL: TestDuplicatePackage (0.07s)
	context_test.go:130: () 
		A: "package": [],
		B: "package": [
		Got:
		{
			"comment": "",
			"ignore": "",
			"package": [],
			"rootPath": "co2"
		}
		
		Want
		{
			"comment": "",
			"ignore": "",
			"package": [
				{
					"checksumSHA1": "1wArEyRQSnOYA1LDiCNvZxF4sm8=",
					"path": "co3/pk3",
					"revision": ""
				}
			],
			"rootPath": "co2"
		}
--- FAIL: TestVendorProgram (0.15s)
	context_test.go:51: A: s  bytes < ["co1/vendor/co2/main"]
		B: l  co1/pk1 < []
		(co1 list) Got
		pv  co1/vendor/co2/main [co2/main] < []
		 e  co3/pk1 < ["co1/vendor/co2/main"]
		 s  bytes < ["co1/vendor/co2/main"]
		 s  fmt < ["co3/pk1"]
		 s  strings < []
		  m notfound < ["co1/vendor/co2/main"]
--- FAIL: TestImportSimple (0.16s)
	context_test.go:51: A: v  co1/vendor/co2/pk1 [co2/pk1] < []
		B: v  co1/vendor/co2/pk1 [co2/pk1] < ["co1/pk1"]
		(same) Got
		 v  co1/vendor/co2/pk1 [co2/pk1] < []
		 s  bytes < []
		 s  strings < ["co1/vendor/co2/pk1"]
--- FAIL: TestNoDep (0.07s)
	context_test.go:51: A: s  strings < []
		B: l  co1/pk1 < []
		(before) Got
		 s  strings < []
--- FAIL: TestMainTest (0.05s)
	context_test.go:51: A: s  strings < []
		B: l  co1/pk1 < []
		(before) Got
		 s  strings < []
--- FAIL: TestUpdate (0.21s)
	context_test.go:51: A: v  co1/vendor/co2/pk1 [co2/pk1] < []
		B: v  co1/vendor/co2/pk1 [co2/pk1] < ["co1/pk1"]
		(co1 after add) Got
		 v  co1/vendor/co2/pk1 [co2/pk1] < []
		 v  co1/vendor/co2/pk1/pk2 [co2/pk1/pk2] < []
		 s  bytes < []
		 s  strings < ["co1/vendor/co2/pk1" "co1/vendor/co2/pk1/pk2"]
--- FAIL: TestVendor (0.05s)
	context_test.go:51: A: s  bytes < []
		B: e  co2/pk1 < ["co1/pk1"]
		(co1 list) Got
		 s  bytes < []
		 s  strings < []
--- FAIL: TestUnused (0.16s)
	context_test.go:51: A: v  co1/vendor/co2/pk1 [co2/pk1] < []
		B: v  co1/vendor/co2/pk1 [co2/pk1] < ["co1/pk1"]
		(co1 after add) Got
		 vu co1/vendor/a [a] < []
		pv  co1/vendor/cmd/main [cmd/main] < []
		 v  co1/vendor/co2/pk1 [co2/pk1] < []
		 vu co1/vendor/co3/pk1 [co3/pk1] < []
		 s  bytes < ["co1/vendor/co2/pk1"]
		 s  encoding/csv < ["co1/vendor/a"]
		 s  strings < ["co1/vendor/cmd/main" "co1/vendor/co3/pk1"]
--- FAIL: TestMissing (0.19s)
	context_test.go:51: A: v  co1/vendor/co2/pk1 [co2/pk1] < []
		B: v  co1/vendor/co2/pk1 [co2/pk1] < ["co1/pk1"]
		(co1 after add) Got
		 v  co1/vendor/co2/pk1 [co2/pk1] < []
		 v  co1/vendor/co3/pk1 [co3/pk1] < []
		 s  bytes < ["co1/vendor/co2/pk1"]
		 s  strings < ["co1/vendor/co3/pk1"]
--- FAIL: TestVendorFile (0.11s)
	context_test.go:51: A: s  bytes < []
		B: e  co2/pk1 < ["co1/pk1"]
		(co1 list) Got
		 s  bytes < []
		 s  strings < []
--- FAIL: TestTestdata (0.16s)
	context_test.go:51: A: v  co1/vendor/co2/pk1 [co2/pk1] < []
		B: v  co1/vendor/co2/pk1 [co2/pk1] < ["co1/pk1"]
		(co1 list) Got
		 v  co1/vendor/co2/pk1 [co2/pk1] < []
		 s  encoding/csv < ["co1/vendor/co2/pk1"]
--- FAIL: TestTagList (0.07s)
	context_test.go:51: A: s  bytes < []
		B: e  co2/pk1 < ["co1/pk1"]
		(co1 before ignore) Got
		 s  bytes < []
		 s  encoding/binary < []
		 s  encoding/csv < []
		 s  encoding/hex < []
		 s  encoding/json < []
		 s  testing < []
--- FAIL: TestTagAdd (0.19s)
	context_test.go:51: A: v  co1/vendor/co2/pk1 [co2/pk1] < []
		B: v  co1/vendor/co2/pk1 [co2/pk1] < ["co1/pk1"]
		(co1 after add) Got
		 v  co1/vendor/co2/pk1 [co2/pk1] < []
		 s  strings < ["co1/vendor/co2/pk1"]
--- FAIL: TestAddMissing (0.01s)
	context_test.go:51: A: m co2/pk1 < []
		B: l  co1/pk1 < []
		(pre) Got
		  m co2/pk1 < []
--- FAIL: TestTree (0.10s)
	context_test.go:51: A: v  co1/vendor/co2/pk1 [co2/pk1] < []
		B: v  co1/vendor/co2/pk1 [co2/pk1] < ["co1/pk1"]
		(co1 after add list) Got
		 v  co1/vendor/co2/pk1 [co2/pk1] < []
		 vt co1/vendor/co2/pk1/go_code [co2/pk1/go_code] < []
		 s  strings < ["co1/vendor/co2/pk1" "co1/vendor/co2/pk1/go_code"]
--- FAIL: TestOriginDir (0.08s)
	context_test.go:51: A: v  co1/vendor/co2/pk1 [co2/pk1] < []
		B: v  co1/vendor/co2/pk1 [co2/pk1] < ["co1/pk1"]
		(pre list) Got
		 v  co1/vendor/co2/pk1 [co2/pk1] < []
		 v  co1/vendor/co2/pk1/sub1 [co2/pk1/sub1] < []
		 s  bytes < ["co1/vendor/co2/pk1/sub1"]
		 s  strings < ["co1/vendor/co2/pk1"]
--- FAIL: TestRelativePath (0.04s)
	context_test.go:51: A: s  bytes < []
		B: e  co2/pk1 < ["co1/pk1"]
		(co1 list) Got
		 s  bytes < []
		 s  strings < []
FAIL
FAIL	github.com/kardianos/govendor/context	18.726s

--- FAIL: TestHasPrefixDirTrue (0.00s)
	prefix_test.go:34: /foo should have / as prefix
	prefix_test.go:34: /foo/bar should have /foo as prefix
	prefix_test.go:34: foo/bar should have foo as prefix
FAIL
FAIL	github.com/kardianos/govendor/internal/vfilepath	0.390s

--- FAIL: TestSimple (0.07s)
	run_test.go:62: () Got
--- FAIL: TestDuplicatePackage (0.12s)
	run_test.go:62: (co1 pre list) Got
--- FAIL: TestEllipsisSimple (0.10s)
	run_test.go:62: () Got
--- FAIL: TestEllipsisRootEmpty (0.08s)
	run_test.go:62: () Got
--- FAIL: TestTreeRootEmpty (0.09s)
	run_test.go:62: () Got
FAIL
FAIL	github.com/kardianos/govendor/run	0.901s
``` 