### PR TITLE
Fails to detect as local on Windows.

### DIFF
--- a/internal/vfilepath/prefix.go
+++ b/internal/vfilepath/prefix.go
@@ -1,7 +1,7 @@
 package vfilepath
 
 import (
-	"path/filepath"
+	"path"
 	"strings"
 )
 
@@ -9,9 +9,9 @@ func HasPrefixDir(path string, prefix string) bool {
 	return strings.HasPrefix(makeDirPath(path), makeDirPath(prefix))
 }
 
-func makeDirPath(path string) string {
-	if path = filepath.Clean(path); path != "/" {
-		path += "/"
+func makeDirPath(dirpath string) string {
+	if dirpath = path.Clean(dirpath); dirpath != "/" {
+		dirpath += "/"
 	}
-	return path
+	return dirpath
 }


### PR DESCRIPTION
#195 was not the compatible change for Windows.

``vfilepath.HasPrefixDir()`` function treats the path strings of Go import and is only referenced from ``context/resolve.go``. The import path string is platform independent so that it is not the right choice to use the functions from ``path/filepath`` package.