### PR TITLE
Issue #221 remove -a flag in install

### DIFF
--- a/run/command.go
+++ b/run/command.go
@@ -78,7 +78,7 @@ func (r *runner) Get(w io.Writer, subCmdArgs []string) (help.HelpMessage, error)
 		if err != nil {
 			return help.MsgNone, err
 		}
-		r.GoCmd("install", []string{a})
+		r.GoCmd("install", []string{})
 	}
 	return help.MsgNone, nil
 }


### PR DESCRIPTION
Specifying the -a flag is not the expected behavior for install. This
forces a recompile of all code, even in the standard library. This does
not work when you're doing static compiles using CGO_ENABLED=0 on linux
because typically the end user does not own those files.

This change removes the '-a' flag as this is only really supposed to be
used by the developers of go.

@see https://github.com/golang/go/issues/15450
@see https://golang.org/cl/10761