### PR TITLE
run: add file path (-p) option to list

### DIFF
--- a/context/status.go
+++ b/context/status.go
@@ -234,7 +234,7 @@ func (ctx *Context) updateStatusCache() error {
 
 		li := StatusItem{
 			Status:       pkg.Status,
-			Pkg:          &pkgspec.Pkg{Path: pkg.Path, IncludeTree: pkg.IncludeTree, Origin: origin, Version: version},
+			Pkg:          &pkgspec.Pkg{Path: pkg.Path, IncludeTree: pkg.IncludeTree, Origin: origin, Version: version, FilePath: pkg.Dir},
 			Local:        pkg.Local,
 			VersionExact: versionExact,
 			ImportedBy:   make([]*Package, 0, len(pkg.referenced)),

--- a/help/text.go
+++ b/help/text.go
@@ -81,9 +81,11 @@ var helpList = `govendor list [options]  ( +status or import-path-filter )
 	List all dependencies and packages in folder tree.
 	Options:
 		-v           verbose listing, show dependencies of each package
+		-p           show file path to package instead of import path
 		-no-status   do not prefix status to list, package names only
 Examples:
 	$ govendor list -no-status +local
+	$ govendor list -p -no-status +local
 	$ govendor list +vend,prog +local,program
 	$ govendor list +local,^prog
 `

--- a/pkgspec/pkg.go
+++ b/pkgspec/pkg.go
@@ -10,6 +10,7 @@ import "bytes"
 
 type Pkg struct {
 	Path        string
+	FilePath    string
 	Origin      string
 	IncludeTree bool
 	MatchTree   bool

--- a/run/list.go
+++ b/run/list.go
@@ -19,6 +19,7 @@ func (r *runner) List(w io.Writer, subCmdArgs []string) (help.HelpMessage, error
 	listFlags := flag.NewFlagSet("list", flag.ContinueOnError)
 	listFlags.SetOutput(nullWriter{})
 	verbose := listFlags.Bool("v", false, "verbose")
+	asFilePath := listFlags.Bool("p", false, "show file path to package instead of import path")
 	noStatus := listFlags.Bool("no-status", false, "do not show the status")
 	err := listFlags.Parse(subCmdArgs)
 	if err != nil {
@@ -105,10 +106,17 @@ func (r *runner) List(w io.Writer, subCmdArgs []string) (help.HelpMessage, error
 			continue
 		}
 
-		if item.Local == item.Pkg.Path {
-			fmt.Fprintf(tw, formatSame, item.Status, item.Pkg.Path, item.Pkg.Version, item.VersionExact)
+		var path string
+		if *asFilePath {
+			path = item.Pkg.FilePath
 		} else {
-			fmt.Fprintf(tw, formatDifferent, item.Status, item.Pkg.Path, strings.TrimPrefix(item.Local, ctx.RootImportPath), item.Pkg.Version, item.VersionExact)
+			path = item.Pkg.Path
+		}
+
+		if item.Local == item.Pkg.Path {
+			fmt.Fprintf(tw, formatSame, item.Status, path, item.Pkg.Version, item.VersionExact)
+		} else {
+			fmt.Fprintf(tw, formatDifferent, item.Status, path, strings.TrimPrefix(item.Local, ctx.RootImportPath), item.Pkg.Version, item.VersionExact)
 		}
 		if *verbose {
 			for i, imp := range item.ImportedBy {


### PR DESCRIPTION
This commit adds a `-p` option to the `list` sub-command that causes
govendor to print the file path to the package instead of the Go import
path.