### PR TITLE
Fixes #245 

### DIFF
--- a/run/command.go
+++ b/run/command.go
@@ -151,5 +151,5 @@ func (r *runner) Status(w io.Writer, subCmdArgs []string) (help.HelpMessage, err
 	for _, pkg := range outOfDate {
 		fmt.Fprintf(w, "\t%s\n", pkg.Path)
 	}
-	return help.MsgNone, nil
+	return help.MsgNone, fmt.Errorf("status failed for %d package(s)", len(outOfDate))
 }


### PR DESCRIPTION
For packages that fail the status command, exits with status code 2 (opposed to previous: 0) and produces the following message.

> The following packages are missing or modified locally:
        github.com/pressly/chi
        github.com/gocql/gocql
Error: status failed for 2 package(s)



