### PR TITLE
Check if revision exists before downloading

### DIFF
--- a/context/sync.go
+++ b/context/sync.go
@@ -356,17 +356,22 @@ func (ctx *Context) Sync(dryrun bool) (err error) {
 				continue
 			}
 		} else {
+			// Use cache.
 			vcsCmd = updateVcsCmd(sysVcsCmd)
-			err = vcsCmd.Download(repoRootDir)
-			if err != nil {
-				rem = append(rem, remoteFailure{Msg: "failed to download repo", Path: vp.Path, Err: err})
-				continue
-			}
 
 			err = vcsCmd.RevisionSync(repoRootDir, vp.Revision)
+			// If revision was not found in the cache, download and try again.
 			if err != nil {
-				rem = append(rem, remoteFailure{Msg: "failed to sync repo to " + vp.Revision, Path: vp.Path, Err: err})
-				continue
+				err = vcsCmd.Download(repoRootDir)
+				if err != nil {
+					rem = append(rem, remoteFailure{Msg: "failed to download repo", Path: vp.Path, Err: err})
+					continue
+				}
+				err = vcsCmd.RevisionSync(repoRootDir, vp.Revision)
+				if err != nil {
+					rem = append(rem, remoteFailure{Msg: "failed to sync repo to " + vp.Revision, Path: vp.Path, Err: err})
+					continue
+				}
 			}
 		}
 		dest := filepath.Join(ctx.RootDir, ctx.VendorFolder, pathos.SlashToFilepath(vp.Path))


### PR DESCRIPTION
The `sync` command is fairly slow even if the cache contains every revision being
synced. This is because a download is attempted even if it is unneeded.

This change changes the flow of `context.Sync` to attempt to `RevisionSync` with
whatever is in the cache, if that fails then it calls `Download` followed by
another `RevisionSync`.

I am making this pull request because at my work we would like to use govendor for our vendoring system, but for doing quick dev builds in docker containers, govendor sync is very slow, even with the cache. We currently use glide which sync's in sub 1 second with a cache, while govendor takes much longer.

Here are before and after time stats for `govendor sync` in `github.com/kardianos/govendor` with an empty vendor directory with the cache up to date.

Current master: `6be156c795774e9e24709ae384d8f4da55e6e192`
```
$ time govendor sync -v
fetch "github.com/Bowery/prompt"
fetch "github.com/dchest/safefile"
fetch "github.com/google/shlex"
fetch "github.com/pkg/errors"
fetch "golang.org/x/tools/go/vcs"

real    0m3.537s
user    0m0.348s
sys     0m0.108s
```

This pull:
```
$ time govendor sync -v
fetch "github.com/Bowery/prompt"
fetch "github.com/dchest/safefile"
fetch "github.com/google/shlex"
fetch "github.com/pkg/errors"
fetch "golang.org/x/tools/go/vcs"

real    0m0.110s
user    0m0.028s
sys     0m0.020s
```

That is over a **3200%** speed increase for real time seconds. And that is only for 5 dependencies. It can be even more dramatic with more dependencies.

I love your tool, please let me know if this pull needs any changes. Please help us switch from glide.