### PR TITLE
Bitbucket ask passwd when forbidden

### DIFF
--- a/vendor/github.com/bgentry/speakeasy/LICENSE_WINDOWS
+++ b/vendor/github.com/bgentry/speakeasy/LICENSE_WINDOWS
@@ -1,0 +1,201 @@
+                              Apache License
+                        Version 2.0, January 2004
+                     http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+   "License" shall mean the terms and conditions for use, reproduction,
+   and distribution as defined by Sections 1 through 9 of this document.
+
+   "Licensor" shall mean the copyright owner or entity authorized by
+   the copyright owner that is granting the License.
+
+   "Legal Entity" shall mean the union of the acting entity and all
+   other entities that control, are controlled by, or are under common
+   control with that entity. For the purposes of this definition,
+   "control" means (i) the power, direct or indirect, to cause the
+   direction or management of such entity, whether by contract or
+   otherwise, or (ii) ownership of fifty percent (50%) or more of the
+   outstanding shares, or (iii) beneficial ownership of such entity.
+
+   "You" (or "Your") shall mean an individual or Legal Entity
+   exercising permissions granted by this License.
+
+   "Source" form shall mean the preferred form for making modifications,
+   including but not limited to software source code, documentation
+   source, and configuration files.
+
+   "Object" form shall mean any form resulting from mechanical
+   transformation or translation of a Source form, including but
+   not limited to compiled object code, generated documentation,
+   and conversions to other media types.
+
+   "Work" shall mean the work of authorship, whether in Source or
+   Object form, made available under the License, as indicated by a
+   copyright notice that is included in or attached to the work
+   (an example is provided in the Appendix below).
+
+   "Derivative Works" shall mean any work, whether in Source or Object
+   form, that is based on (or derived from) the Work and for which the
+   editorial revisions, annotations, elaborations, or other modifications
+   represent, as a whole, an original work of authorship. For the purposes
+   of this License, Derivative Works shall not include works that remain
+   separable from, or merely link (or bind by name) to the interfaces of,
+   the Work and Derivative Works thereof.
+
+   "Contribution" shall mean any work of authorship, including
+   the original version of the Work and any modifications or additions
+   to that Work or Derivative Works thereof, that is intentionally
+   submitted to Licensor for inclusion in the Work by the copyright owner
+   or by an individual or Legal Entity authorized to submit on behalf of
+   the copyright owner. For the purposes of this definition, "submitted"
+   means any form of electronic, verbal, or written communication sent
+   to the Licensor or its representatives, including but not limited to
+   communication on electronic mailing lists, source code control systems,
+   and issue tracking systems that are managed by, or on behalf of, the
+   Licensor for the purpose of discussing and improving the Work, but
+   excluding communication that is conspicuously marked or otherwise
+   designated in writing by the copyright owner as "Not a Contribution."
+
+   "Contributor" shall mean Licensor and any individual or Legal Entity
+   on behalf of whom a Contribution has been received by Licensor and
+   subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   copyright license to reproduce, prepare Derivative Works of,
+   publicly display, publicly perform, sublicense, and distribute the
+   Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   (except as stated in this section) patent license to make, have made,
+   use, offer to sell, sell, import, and otherwise transfer the Work,
+   where such license applies only to those patent claims licensable
+   by such Contributor that are necessarily infringed by their
+   Contribution(s) alone or by combination of their Contribution(s)
+   with the Work to which such Contribution(s) was submitted. If You
+   institute patent litigation against any entity (including a
+   cross-claim or counterclaim in a lawsuit) alleging that the Work
+   or a Contribution incorporated within the Work constitutes direct
+   or contributory patent infringement, then any patent licenses
+   granted to You under this License for that Work shall terminate
+   as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the
+   Work or Derivative Works thereof in any medium, with or without
+   modifications, and in Source or Object form, provided that You
+   meet the following conditions:
+
+   (a) You must give any other recipients of the Work or
+       Derivative Works a copy of this License; and
+
+   (b) You must cause any modified files to carry prominent notices
+       stating that You changed the files; and
+
+   (c) You must retain, in the Source form of any Derivative Works
+       that You distribute, all copyright, patent, trademark, and
+       attribution notices from the Source form of the Work,
+       excluding those notices that do not pertain to any part of
+       the Derivative Works; and
+
+   (d) If the Work includes a "NOTICE" text file as part of its
+       distribution, then any Derivative Works that You distribute must
+       include a readable copy of the attribution notices contained
+       within such NOTICE file, excluding those notices that do not
+       pertain to any part of the Derivative Works, in at least one
+       of the following places: within a NOTICE text file distributed
+       as part of the Derivative Works; within the Source form or
+       documentation, if provided along with the Derivative Works; or,
+       within a display generated by the Derivative Works, if and
+       wherever such third-party notices normally appear. The contents
+       of the NOTICE file are for informational purposes only and
+       do not modify the License. You may add Your own attribution
+       notices within Derivative Works that You distribute, alongside
+       or as an addendum to the NOTICE text from the Work, provided
+       that such additional attribution notices cannot be construed
+       as modifying the License.
+
+   You may add Your own copyright statement to Your modifications and
+   may provide additional or different license terms and conditions
+   for use, reproduction, or distribution of Your modifications, or
+   for any such Derivative Works as a whole, provided Your use,
+   reproduction, and distribution of the Work otherwise complies with
+   the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise,
+   any Contribution intentionally submitted for inclusion in the Work
+   by You to the Licensor shall be under the terms and conditions of
+   this License, without any additional terms or conditions.
+   Notwithstanding the above, nothing herein shall supersede or modify
+   the terms of any separate license agreement you may have executed
+   with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade
+   names, trademarks, service marks, or product names of the Licensor,
+   except as required for reasonable and customary use in describing the
+   origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or
+   agreed to in writing, Licensor provides the Work (and each
+   Contributor provides its Contributions) on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied, including, without limitation, any warranties or conditions
+   of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+   PARTICULAR PURPOSE. You are solely responsible for determining the
+   appropriateness of using or redistributing the Work and assume any
+   risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory,
+   whether in tort (including negligence), contract, or otherwise,
+   unless required by applicable law (such as deliberate and grossly
+   negligent acts) or agreed to in writing, shall any Contributor be
+   liable to You for damages, including any direct, indirect, special,
+   incidental, or consequential damages of any character arising as a
+   result of this License or out of the use or inability to use the
+   Work (including but not limited to damages for loss of goodwill,
+   work stoppage, computer failure or malfunction, or any and all
+   other commercial damages or losses), even if such Contributor
+   has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing
+   the Work or Derivative Works thereof, You may choose to offer,
+   and charge a fee for, acceptance of support, warranty, indemnity,
+   or other liability obligations and/or rights consistent with this
+   License. However, in accepting such obligations, You may act only
+   on Your own behalf and on Your sole responsibility, not on behalf
+   of any other Contributor, and only if You agree to indemnify,
+   defend, and hold each Contributor harmless for any liability
+   incurred by, or claims asserted against, such Contributor by reason
+   of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work.
+
+   To apply the Apache License to your work, attach the following
+   boilerplate notice, with the fields enclosed by brackets "[]"
+   replaced with your own identifying information. (Don't include
+   the brackets!)  The text should be enclosed in the appropriate
+   comment syntax for the file format. We also recommend that a
+   file or class name and description of purpose be included on the
+   same "printed page" as the copyright notice for easier
+   identification within third-party archives.
+
+Copyright [2013] [the CloudFoundry Authors]
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/vendor/github.com/bgentry/speakeasy/Readme.md
+++ b/vendor/github.com/bgentry/speakeasy/Readme.md
@@ -1,0 +1,30 @@
+# Speakeasy
+
+This package provides cross-platform Go (#golang) helpers for taking user input
+from the terminal while not echoing the input back (similar to `getpasswd`). The
+package uses syscalls to avoid any dependence on cgo, and is therefore
+compatible with cross-compiling.
+
+[![GoDoc](https://godoc.org/github.com/bgentry/speakeasy?status.png)][godoc]
+
+## Unicode
+
+Multi-byte unicode characters work successfully on Mac OS X. On Windows,
+however, this may be problematic (as is UTF in general on Windows). Other
+platforms have not been tested.
+
+## License
+
+The code herein was not written by me, but was compiled from two separate open
+source packages. Unix portions were imported from [gopass][gopass], while
+Windows portions were imported from the [CloudFoundry Go CLI][cf-cli]'s
+[Windows terminal helpers][cf-ui-windows].
+
+The [license for the windows portion](./LICENSE_WINDOWS) has been copied exactly
+from the source (though I attempted to fill in the correct owner in the
+boilerplate copyright notice).
+
+[cf-cli]: https://github.com/cloudfoundry/cli "CloudFoundry Go CLI"
+[cf-ui-windows]: https://github.com/cloudfoundry/cli/blob/master/src/cf/terminal/ui_windows.go "CloudFoundry Go CLI Windows input helpers"
+[godoc]: https://godoc.org/github.com/bgentry/speakeasy "speakeasy on Godoc.org"
+[gopass]: https://code.google.com/p/gopass "gopass"

--- a/vendor/github.com/bgentry/speakeasy/speakeasy.go
+++ b/vendor/github.com/bgentry/speakeasy/speakeasy.go
@@ -1,0 +1,49 @@
+package speakeasy
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"strings"
+)
+
+// Ask the user to enter a password with input hidden. prompt is a string to
+// display before the user's input. Returns the provided password, or an error
+// if the command failed.
+func Ask(prompt string) (password string, err error) {
+	return FAsk(os.Stdout, prompt)
+}
+
+// FAsk is the same as Ask, except it is possible to specify the file to write
+// the prompt to. If 'nil' is passed as the writer, no prompt will be written.
+func FAsk(wr io.Writer, prompt string) (password string, err error) {
+	if wr != nil && prompt != "" {
+		fmt.Fprint(wr, prompt) // Display the prompt.
+	}
+	password, err = getPassword()
+
+	// Carriage return after the user input.
+	if wr != nil {
+		fmt.Fprintln(wr, "")
+	}
+	return
+}
+
+func readline() (value string, err error) {
+	var valb []byte
+	var n int
+	b := make([]byte, 1)
+	for {
+		// read one byte at a time so we don't accidentally read extra bytes
+		n, err = os.Stdin.Read(b)
+		if err != nil && err != io.EOF {
+			return "", err
+		}
+		if n == 0 || b[0] == '\n' {
+			break
+		}
+		valb = append(valb, b[0])
+	}
+
+	return strings.TrimSuffix(string(valb), "\r"), nil
+}

--- a/vendor/github.com/bgentry/speakeasy/speakeasy_unix.go
+++ b/vendor/github.com/bgentry/speakeasy/speakeasy_unix.go
@@ -1,0 +1,93 @@
+// based on https://code.google.com/p/gopass
+// Author: johnsiilver@gmail.com (John Doak)
+//
+// Original code is based on code by RogerV in the golang-nuts thread:
+// https://groups.google.com/group/golang-nuts/browse_thread/thread/40cc41e9d9fc9247
+
+// +build darwin dragonfly freebsd linux netbsd openbsd solaris
+
+package speakeasy
+
+import (
+	"fmt"
+	"os"
+	"os/signal"
+	"strings"
+	"syscall"
+)
+
+const sttyArg0 = "/bin/stty"
+
+var (
+	sttyArgvEOff = []string{"stty", "-echo"}
+	sttyArgvEOn  = []string{"stty", "echo"}
+)
+
+// getPassword gets input hidden from the terminal from a user. This is
+// accomplished by turning off terminal echo, reading input from the user and
+// finally turning on terminal echo.
+func getPassword() (password string, err error) {
+	sig := make(chan os.Signal, 10)
+	brk := make(chan bool)
+
+	// File descriptors for stdin, stdout, and stderr.
+	fd := []uintptr{os.Stdin.Fd(), os.Stdout.Fd(), os.Stderr.Fd()}
+
+	// Setup notifications of termination signals to channel sig, create a process to
+	// watch for these signals so we can turn back on echo if need be.
+	signal.Notify(sig, syscall.SIGHUP, syscall.SIGINT, syscall.SIGKILL, syscall.SIGQUIT,
+		syscall.SIGTERM)
+	go catchSignal(fd, sig, brk)
+
+	// Turn off the terminal echo.
+	pid, err := echoOff(fd)
+	if err != nil {
+		return "", err
+	}
+
+	// Turn on the terminal echo and stop listening for signals.
+	defer signal.Stop(sig)
+	defer close(brk)
+	defer echoOn(fd)
+
+	syscall.Wait4(pid, nil, 0, nil)
+
+	line, err := readline()
+	if err == nil {
+		password = strings.TrimSpace(line)
+	} else {
+		err = fmt.Errorf("failed during password entry: %s", err)
+	}
+
+	return password, err
+}
+
+// echoOff turns off the terminal echo.
+func echoOff(fd []uintptr) (int, error) {
+	pid, err := syscall.ForkExec(sttyArg0, sttyArgvEOff, &syscall.ProcAttr{Dir: "", Files: fd})
+	if err != nil {
+		return 0, fmt.Errorf("failed turning off console echo for password entry:\n\t%s", err)
+	}
+	return pid, nil
+}
+
+// echoOn turns back on the terminal echo.
+func echoOn(fd []uintptr) {
+	// Turn on the terminal echo.
+	pid, e := syscall.ForkExec(sttyArg0, sttyArgvEOn, &syscall.ProcAttr{Dir: "", Files: fd})
+	if e == nil {
+		syscall.Wait4(pid, nil, 0, nil)
+	}
+}
+
+// catchSignal tries to catch SIGKILL, SIGQUIT and SIGINT so that we can turn
+// terminal echo back on before the program ends. Otherwise the user is left
+// with echo off on their terminal.
+func catchSignal(fd []uintptr, sig chan os.Signal, brk chan bool) {
+	select {
+	case <-sig:
+		echoOn(fd)
+		os.Exit(-1)
+	case <-brk:
+	}
+}

--- a/vendor/github.com/bgentry/speakeasy/speakeasy_windows.go
+++ b/vendor/github.com/bgentry/speakeasy/speakeasy_windows.go
@@ -1,0 +1,41 @@
+// +build windows
+
+package speakeasy
+
+import (
+	"syscall"
+)
+
+// SetConsoleMode function can be used to change value of ENABLE_ECHO_INPUT:
+// http://msdn.microsoft.com/en-us/library/windows/desktop/ms686033(v=vs.85).aspx
+const ENABLE_ECHO_INPUT = 0x0004
+
+func getPassword() (password string, err error) {
+	var oldMode uint32
+
+	err = syscall.GetConsoleMode(syscall.Stdin, &oldMode)
+	if err != nil {
+		return
+	}
+
+	var newMode uint32 = (oldMode &^ ENABLE_ECHO_INPUT)
+
+	err = setConsoleMode(syscall.Stdin, newMode)
+	defer setConsoleMode(syscall.Stdin, oldMode)
+	if err != nil {
+		return
+	}
+
+	return readline()
+}
+
+func setConsoleMode(console syscall.Handle, mode uint32) (err error) {
+	dll := syscall.MustLoadDLL("kernel32")
+	proc := dll.MustFindProc("SetConsoleMode")
+	r, _, err := proc.Call(uintptr(console), uintptr(mode))
+
+	if r == 0 {
+		return err
+	}
+	return nil
+}

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -9,6 +9,12 @@
 			"revisionTime": "2016-08-08T16:52:56Z"
 		},
 		{
+			"checksumSHA1": "Isa9x3nvIJ12hvgdvUUBty+yplU=",
+			"path": "github.com/bgentry/speakeasy",
+			"revision": "675b82c74c0ed12283ee81ba8a534c8982c07b85",
+			"revisionTime": "2016-10-13T10:26:35Z"
+		},
+		{
 			"checksumSHA1": "6VGFARaK8zd23IAiDf7a+gglC8k=",
 			"path": "github.com/dchest/safefile",
 			"revision": "855e8d98f1852d48dde521e0522408d1fe7e836a",


### PR DESCRIPTION
When trying to fetch a revision from a private bitbucket repository, govendor fails when trying to access the bitbucket api. The request needs to be authenticated with basic auth. ( https://confluence.atlassian.com/bitbucket/use-the-bitbucket-cloud-rest-apis-222724129.html )

I extended the error to contain the original message and extended the interal api with non-breaking-changes so we can authenticate requests.