### PR TITLE
Update github.com/Bowery/prompt

### DIFF
--- a/vendor/github.com/Bowery/prompt/CONTRIBUTORS.md
+++ b/vendor/github.com/Bowery/prompt/CONTRIBUTORS.md
@@ -1,0 +1,7 @@
+- [Larz Conwell](https://github.com/larzconwell)
+- [Steve Kaliski](https://github.com/sjkaliski)
+- [NHOrus](https://github.com/NHOrus)
+- [Attila Fülöp](https://github.com/AttilaFueloep)
+- [Gereon Frey](https://github.com/gfrey)
+- [Aaron Bieber](https://github.com/qbit)
+- [Ricky Medina](https://github.com/r-medina)

--- a/vendor/github.com/Bowery/prompt/term_solaris_ioctl.go
+++ b/vendor/github.com/Bowery/prompt/term_solaris_ioctl.go
@@ -1,0 +1,37 @@
+// +build solaris
+
+// Copyright 2017 Bowery, Inc.
+
+package prompt
+
+import (
+	"os"
+	"golang.org/x/sys/unix"
+
+)
+
+type Termios unix.Termios
+
+// setTermios does the system dependent ioctl calls
+func setTermios(fd uintptr, req uintptr, termios *Termios) error {
+	return unix.IoctlSetTermios(int(fd), int(req), (*unix.Termios)(termios))
+}
+
+// getTermios does the system dependent ioctl calls
+func getTermios(fd uintptr, req uintptr) (*Termios, error) {
+	termios, err := unix.IoctlGetTermios(int(fd), int(req))
+	if err != nil {
+		return nil, err
+	}
+	return (*Termios)(termios), nil
+}
+
+// TerminalSize retrieves the cols/rows for the terminal connected to out.
+func TerminalSize(out *os.File) (int, int, error) {
+	ws, err := unix.IoctlGetWinsize(int(out.Fd()), unix.TIOCGWINSZ)
+
+	if err != nil {
+		return 0, 0, err
+	}
+	return int(ws.Col), int(ws.Row), nil
+}

--- a/vendor/github.com/Bowery/prompt/term_unix.go
+++ b/vendor/github.com/Bowery/prompt/term_unix.go
@@ -8,7 +8,6 @@ import (
 	"bufio"
 	"os"
 	"syscall"
-	"unsafe"
 )
 
 var unsupported = []string{"", "dumb", "cons25"}
@@ -26,27 +25,6 @@ func supportedTerminal() bool {
 	return true
 }
 
-// winsize contains the size for the terminal.
-type winsize struct {
-	rows   uint16
-	cols   uint16
-	xpixel uint16
-	ypixel uint16
-}
-
-// TerminalSize retrieves the cols/rows for the terminal connected to out.
-func TerminalSize(out *os.File) (int, int, error) {
-	ws := new(winsize)
-
-	_, _, err := syscall.Syscall(syscall.SYS_IOCTL, out.Fd(),
-		uintptr(syscall.TIOCGWINSZ), uintptr(unsafe.Pointer(ws)))
-	if err != 0 {
-		return 0, 0, err
-	}
-
-	return int(ws.cols), int(ws.rows), nil
-}
-
 // IsNotTerminal checks if an error is related to io not being a terminal.
 func IsNotTerminal(err error) bool {
 	if err == syscall.ENOTTY {
@@ -60,7 +38,7 @@ func IsNotTerminal(err error) bool {
 type terminal struct {
 	supported    bool
 	simpleReader *bufio.Reader
-	origMode     syscall.Termios
+	origMode     Termios
 }
 
 // NewTerminal creates a terminal and sets it to raw input mode.
@@ -75,16 +53,15 @@ func NewTerminal() (*Terminal, error) {
 	if !supportedTerminal() {
 		return term, nil
 	}
-
-	_, _, err := syscall.Syscall(syscall.SYS_IOCTL, term.In.Fd(),
-		uintptr(tcgets), uintptr(unsafe.Pointer(&term.origMode)))
-	if err != 0 {
+	t, err := getTermios(term.In.Fd(), uintptr(tcgets))
+	if err != nil {
 		if IsNotTerminal(err) {
 			return term, nil
 		}
 
 		return nil, err
 	}
+	term.origMode = *t
 	mode := term.origMode
 	term.supported = true
 
@@ -105,9 +82,8 @@ func NewTerminal() (*Terminal, error) {
 	mode.Cc[syscall.VMIN] = 1
 	mode.Cc[syscall.VTIME] = 0
 
-	_, _, err = syscall.Syscall(syscall.SYS_IOCTL, term.In.Fd(),
-		uintptr(tcsetsf), uintptr(unsafe.Pointer(&mode)))
-	if err != 0 {
+	err = setTermios(term.In.Fd(), uintptr(tcsetsf), &mode)
+	if err != nil {
 		return nil, err
 	}
 
@@ -137,9 +113,8 @@ func (term *Terminal) GetPassword(prefix string) (string, error) {
 // Close disables the terminals raw input.
 func (term *Terminal) Close() error {
 	if term.supported {
-		_, _, err := syscall.Syscall(syscall.SYS_IOCTL, term.In.Fd(),
-			uintptr(tcsets), uintptr(unsafe.Pointer(&term.origMode)))
-		if err != 0 {
+		err := setTermios(term.In.Fd(), uintptr(tcsets), &term.origMode)
+		if err != nil {
 			return err
 		}
 	}

--- a/vendor/github.com/Bowery/prompt/term_unix_ioctl.go
+++ b/vendor/github.com/Bowery/prompt/term_unix_ioctl.go
@@ -1,0 +1,56 @@
+// +build linux darwin freebsd openbsd netbsd dragonfly
+
+// Copyright 2013-2015 Bowery, Inc.
+
+package prompt
+
+import (
+	"os"
+	"syscall"
+	"unsafe"
+)
+
+type Termios syscall.Termios
+
+// setTermios does the system dependent ioctl calls
+func getTermios(fd uintptr, req uintptr) (*Termios, error) {
+	termios := new(syscall.Termios)
+	_, _, err := syscall.Syscall(syscall.SYS_IOCTL, fd, req,
+		uintptr(unsafe.Pointer(termios)))
+
+	if err != 0 {
+		return nil, err
+	}
+	return (*Termios)(termios), nil
+}
+
+// setTermios does the system dependent ioctl calls
+func setTermios(fd uintptr, req uintptr, termios *Termios) error {
+	_, _, err := syscall.Syscall(syscall.SYS_IOCTL, fd, req,
+		uintptr(unsafe.Pointer(termios)))
+
+	if err != 0 {
+		return err
+	}
+	return nil
+}
+
+// winsize contains the size for the terminal.
+type winsize struct {
+	rows   uint16
+	cols   uint16
+	xpixel uint16
+	ypixel uint16
+}
+
+// TerminalSize retrieves the cols/rows for the terminal connected to out.
+func TerminalSize(out *os.File) (int, int, error) {
+	ws := new(winsize)
+
+	_, _, err := syscall.Syscall(syscall.SYS_IOCTL, out.Fd(),
+		uintptr(syscall.TIOCGWINSZ), uintptr(unsafe.Pointer(ws)))
+	if err != 0 {
+		return 0, 0, err
+	}
+	return int(ws.cols), int(ws.rows), nil
+}

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -3,10 +3,10 @@
 	"ignore": "test",
 	"package": [
 		{
-			"checksumSHA1": "mBpqi6N3JJTdSpq71vI8vwuffl8=",
+			"checksumSHA1": "GMO8r3qzoHlPklY2QX9AaMv1mwE=",
 			"path": "github.com/Bowery/prompt",
-			"revision": "2708577f3274d7884e1c737218c625f651ba14b3",
-			"revisionTime": "2017-02-08T14:51:51Z"
+			"revision": "3d81310f21c3919c7a0001b57856f08739b2b3fb",
+			"revisionTime": "2017-02-16T05:18:37Z"
 		},
 		{
 			"checksumSHA1": "6VGFARaK8zd23IAiDf7a+gglC8k=",


### PR DESCRIPTION
The version I added previously didn't work with solaris either. The go
package the OpenIndiana Hipster package manager installed had a patch
adding syscalls the original go package doesn't have. This version now
will work properly (tested with the named go pkg and the original
go1.8rc1).

Sorry for the inconvience!