### PR TITLE
Treat symlinked GOPATH correctly

### DIFF
--- a/context/context.go
+++ b/context/context.go
@@ -198,7 +198,12 @@ func NewContext(root, vendorFilePathRel, vendorFolder string, rewriteImports boo
 	gopathGoroot := make([]string, 0, len(gopathList)+1)
 	gopathGoroot = append(gopathGoroot, goroot)
 	for _, gopath := range gopathList {
-		gopathGoroot = append(gopathGoroot, filepath.Join(gopath, "src")+string(filepath.Separator))
+		srcPath := filepath.Join(gopath, "src") + string(filepath.Separator)
+		srcPathEvaled, err := filepath.EvalSymlinks(srcPath)
+		if err != nil {
+			return nil, err
+		}
+		gopathGoroot = append(gopathGoroot, srcPath, srcPathEvaled+string(filepath.Separator))
 	}
 
 	rootToVendorFile, _ := filepath.Split(vendorFilePathRel)

--- a/context/path.go
+++ b/context/path.go
@@ -91,11 +91,23 @@ func (ctx *Context) findImportDir(relative, importPath string) (dir, gopath stri
 
 // findImportPath takes a absolute directory and returns the import path and go path.
 func (ctx *Context) findImportPath(dir string) (importPath, gopath string, err error) {
+	dirResolved, err := filepath.EvalSymlinks(dir)
+	if err != nil {
+		return "", "", err
+	}
+	dirs := make([]string, 1)
+	dirs = append(dirs, dir)
+	if dir != dirResolved {
+		dirs = append(dirs, dirResolved)
+	}
+
 	for _, gopath := range ctx.GopathList {
-		if pathos.FileHasPrefix(dir, gopath) {
-			importPath = pathos.FileTrimPrefix(dir, gopath)
-			importPath = pathos.SlashToImportPath(importPath)
-			return importPath, gopath, nil
+		for _, dir := range dirs {
+			if pathos.FileHasPrefix(dir, gopath) {
+				importPath = pathos.FileTrimPrefix(dir, gopath)
+				importPath = pathos.SlashToImportPath(importPath)
+				return importPath, gopath, nil
+			}
 		}
 	}
 	return "", "", ErrNotInGOPATH{dir}


### PR DESCRIPTION
Right now $GOPATH can not be a symlink because govendor throws the
following error:

    Error: Package "/Users/me/Developer/project" not a go package or not in GOPATH.

This breaks typical Mac OS X setup when go is installed with homebrew
because $GOPATH is a symlink:

    % echo $GOPATH
    /usr/local/opt/go
    % ls -l /usr/local/opt/go
    /usr/local/opt/go -> ../Cellar/go/1.8

Fixes #260