### PR TITLE
internal/pathos: avoid lower-casing strings when possible

### DIFF
--- a/internal/pathos/path.go
+++ b/internal/pathos/path.go
@@ -17,16 +17,16 @@ func SlashToFilepath(path string) string {
 	}
 	return strings.Replace(path, "/", string(filepath.Separator), -1)
 }
+
 func SlashToImportPath(path string) string {
 	return strings.Replace(path, `\`, "/", -1)
 }
 
 func FileHasPrefix(s, prefix string) bool {
-	if runtime.GOOS == "windows" || runtime.GOOS == "darwin" {
-		s = strings.ToLower(s)
-		prefix = strings.ToLower(prefix)
+	if len(prefix) > len(s) {
+		return false
 	}
-	return strings.HasPrefix(s, prefix)
+	return caseInsensitiveEq(s[:len(prefix)], prefix)
 }
 
 func FileTrimPrefix(s, prefix string) string {
@@ -37,11 +37,10 @@ func FileTrimPrefix(s, prefix string) string {
 }
 
 func FileHasSuffix(s, suffix string) bool {
-	if runtime.GOOS == "windows" || runtime.GOOS == "darwin" {
-		s = strings.ToLower(s)
-		suffix = strings.ToLower(suffix)
+	if len(suffix) > len(s) {
+		return false
 	}
-	return strings.HasSuffix(s, suffix)
+	return caseInsensitiveEq(s[len(s)-len(suffix):], suffix)
 }
 
 func FileTrimSuffix(s, suffix string) string {
@@ -96,10 +95,6 @@ func FileStringEquals(s1, s2 string) bool {
 	if len(s2) == 0 {
 		return len(s1) == 0
 	}
-	if runtime.GOOS == "windows" || runtime.GOOS == "darwin" {
-		s1 = strings.ToLower(s1)
-		s2 = strings.ToLower(s2)
-	}
 	r1End := s1[len(s1)-1]
 	r2End := s2[len(s2)-1]
 	if r1End == '/' || r1End == '\\' {
@@ -107,6 +102,13 @@ func FileStringEquals(s1, s2 string) bool {
 	}
 	if r2End == '/' || r2End == '\\' {
 		s2 = s2[:len(s2)-1]
+	}
+	return caseInsensitiveEq(s1, s2)
+}
+
+func caseInsensitiveEq(s1, s2 string) bool {
+	if runtime.GOOS == "windows" || runtime.GOOS == "darwin" {
+		return strings.EqualFold(s1, s2)
 	}
 	return s1 == s2
 }


### PR DESCRIPTION
FileHasPrefix, FileHasSuffix, FileStringEquals use a case-insensitive
comparison on darwin and windows. Avoiding allocation in those (hot)
functions reduces `govendor list` time from 7s to 1.5s for my project.