### PR TITLE
Add profile instrumentation

### DIFF
--- a/help/text.go
+++ b/help/text.go
@@ -165,6 +165,8 @@ var helpLicense = `govendor license [options] ( +status or package-spec )
 `
 var helpShell = `govendor shell
 	Open a govendor "shell". Useful for faster queries on large projects.
+	Options:
+		-pprof-handler    expose a pprof HTTP server on the given address
 `
 
 var msgGovendorVersion = version + `

--- a/help/text.go
+++ b/help/text.go
@@ -15,6 +15,8 @@ import (
 var helpFull = `govendor (` + version + `): record dependencies and copy into vendor folder
 	-govendor-licenses    Show govendor's licenses.
 	-version              Show govendor version
+	-cpuprofile 'file'    Writes a CPU profile to 'file' for debugging.
+	-memprofile 'file'    Writes a heap profile to 'file' for debugging.
 
 Sub-Commands
 

--- a/run/shell.go
+++ b/run/shell.go
@@ -8,7 +8,11 @@ import (
 	"flag"
 	"fmt"
 	"io"
+	"net"
 	"os"
+
+	"net/http"
+	_ "net/http/pprof" // imported for side effect of registering handler
 
 	"github.com/kardianos/govendor/help"
 
@@ -18,10 +22,17 @@ import (
 
 func (r *runner) Shell(w io.Writer, subCmdArgs []string) (help.HelpMessage, error) {
 	flags := flag.NewFlagSet("shell", flag.ContinueOnError)
+
+	pprofHandlerAddr := flags.String("pprof-handler", "localhost:0", "if set, turns on an HTTP server that offers pprof handlers")
+
 	flags.SetOutput(nullWriter{})
 	err := flags.Parse(subCmdArgs)
 	if err != nil {
 		return help.MsgShell, err
+	}
+
+	if *pprofHandlerAddr != "" {
+		go tryEnableHTTPPprofHandler(*pprofHandlerAddr)
 	}
 
 	out := os.Stdout
@@ -59,4 +70,23 @@ func (r *runner) Shell(w io.Writer, subCmdArgs []string) (help.HelpMessage, erro
 	}
 
 	return help.MsgNone, nil
+}
+
+// tryEnableHTTPPprofHandler tries to provide an http/pprof handler on `addr`.
+// if it fails, it logs an error but does not otherwise do anything.
+func tryEnableHTTPPprofHandler(addr string) {
+	l, err := net.Listen("tcp", addr)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "http/pprof handler failed to create a listener: %v\n", err)
+		return
+	}
+	defer l.Close()
+	// port 0 means a randomly allocated one, so we
+	// need to figure out where our listener ended up
+	realAddr := l.Addr()
+
+	fmt.Fprintf(os.Stderr, "http/pprof handler are available on %v\n", realAddr)
+	if err := http.Serve(l, nil); err != nil {
+		fmt.Fprintf(os.Stderr, "http/pprof handler failed to start: %v\n", err)
+	}
 }

--- a/run/shell.go
+++ b/run/shell.go
@@ -32,7 +32,7 @@ func (r *runner) Shell(w io.Writer, subCmdArgs []string) (help.HelpMessage, erro
 	}
 
 	if *pprofHandlerAddr != "" {
-		go tryEnableHTTPPprofHandler(*pprofHandlerAddr)
+		tryEnableHTTPPprofHandler(*pprofHandlerAddr)
 	}
 
 	out := os.Stdout
@@ -77,16 +77,18 @@ func (r *runner) Shell(w io.Writer, subCmdArgs []string) (help.HelpMessage, erro
 func tryEnableHTTPPprofHandler(addr string) {
 	l, err := net.Listen("tcp", addr)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "http/pprof handler failed to create a listener: %v\n", err)
+		fmt.Fprintf(os.Stderr, "http/pprof handlers failed to create a listener: %v\n", err)
 		return
 	}
-	defer l.Close()
 	// port 0 means a randomly allocated one, so we
 	// need to figure out where our listener ended up
 	realAddr := l.Addr()
 
-	fmt.Fprintf(os.Stderr, "http/pprof handler are available on %v\n", realAddr)
-	if err := http.Serve(l, nil); err != nil {
-		fmt.Fprintf(os.Stderr, "http/pprof handler failed to start: %v\n", err)
-	}
+	fmt.Fprintf(os.Stderr, "http/pprof handlers are available on %v\n", realAddr)
+	go func() {
+		defer l.Close()
+		if err := http.Serve(l, nil); err != nil {
+			fmt.Fprintf(os.Stderr, "http/pprof handlers failed to start: %v\n", err)
+		}
+	}()
 }

--- a/run/shell.go
+++ b/run/shell.go
@@ -23,7 +23,7 @@ import (
 func (r *runner) Shell(w io.Writer, subCmdArgs []string) (help.HelpMessage, error) {
 	flags := flag.NewFlagSet("shell", flag.ContinueOnError)
 
-	pprofHandlerAddr := flags.String("pprof-handler", "localhost:0", "if set, turns on an HTTP server that offers pprof handlers")
+	pprofHandlerAddr := flags.String("pprof-handler", "", "if set, turns on an HTTP server that offers pprof handlers")
 
 	flags.SetOutput(nullWriter{})
 	err := flags.Parse(subCmdArgs)


### PR DESCRIPTION
I'm facing performance issues using `govendor` on a large project on OS X. To help guide my investigation, this adds support for profiling both in CLI mode and in `shell` mode. 

The `shell` mode has the advantage of being long-lived, so it can offer a larger variety of `pprof` handlers on the `net/http/pprof` handlers.

