### PR TITLE
Fix typos in comments and doc/implementation.md

### DIFF
--- a/context/context.go
+++ b/context/context.go
@@ -56,9 +56,9 @@ type Context struct {
 	// Package is a map where the import path is the key.
 	// Populated with LoadPackage.
 	Package map[string]*Package
-	// Change to unkown structure (rename). Maybe...
+	// Change to unknown structure (rename). Maybe...
 
-	// MoveRule provides the translation from origional import path to new import path.
+	// MoveRule provides the translation from original import path to new import path.
 	RewriteRule map[string]string // map[from]to
 
 	Operation []*Operation
@@ -84,7 +84,7 @@ type Package struct {
 	Gopath string // Includes trailing "src".
 	Files  []*File
 
-	inVendor bool // Different then Status.Location, this is in *any* vendor tree.
+	inVendor bool // Different than Status.Location, this is in *any* vendor tree.
 	inTree   bool
 
 	ignoreFile []string

--- a/context/label.go
+++ b/context/label.go
@@ -184,7 +184,7 @@ func (l labelAnalysisList) Less(i, j int) bool {
 			return true
 		}
 	}
-	// We ran out of things to check. Assume one is not "less" then the other.
+	// We ran out of things to check. Assume one is not "less" than the other.
 	df("PT D\n")
 	return false
 }

--- a/context/modify.go
+++ b/context/modify.go
@@ -535,7 +535,7 @@ func (ctx *Context) modifyFetch(pkg *Package, uncommitted, hasVersion bool, vers
 	return nil
 }
 
-// Check returns any conflicts when more then one package can be moved into
+// Check returns any conflicts when more than one package can be moved into
 // the same path.
 func (ctx *Context) Check() []*Conflict {
 	// Find duplicate packages that have been marked for moving.

--- a/context/resolve.go
+++ b/context/resolve.go
@@ -154,7 +154,7 @@ func (ctx *Context) addFileImports(pathname, gopath string) (*Package, error) {
 	if strings.HasSuffix(pathname, ".go") == false {
 		return nil, nil
 	}
-	// No need to add the same file more then once.
+	// No need to add the same file more than once.
 	for _, pkg := range ctx.Package {
 		if pathos.FileStringEquals(pkg.Dir, dir) == false {
 			continue

--- a/context/status.go
+++ b/context/status.go
@@ -55,7 +55,7 @@ func (s Status) String() string {
 	}
 	switch s.Location {
 	default:
-		panic("Unkown Location type")
+		panic("Unknown Location type")
 	case LocationUnknown:
 		l = '_'
 	case LocationNotFound:

--- a/context/tags.go
+++ b/context/tags.go
@@ -11,8 +11,8 @@ import (
 
 // Build tags come in the format "tagA tagB,tagC" -> "taga OR (tagB AND tagC)"
 // File tags compose with this as "ftag1 AND ftag2 AND (<build-tags>)".
-// However in govendor all questions are reversed. Rather then asking
-// "What should be built?" we ask "What should be ingored?".
+// However in govendor all questions are reversed. Rather than asking
+// "What should be built?" we ask "What should be ignored?".
 
 type logical struct {
 	and bool
@@ -31,7 +31,7 @@ func (lt logicalTag) match(lt2 logicalTag) bool {
 	if lt.not || lt2.not {
 		return false
 	}
-	if lt.tag == lt2.tag{
+	if lt.tag == lt2.tag {
 		return true
 	}
 
@@ -72,7 +72,7 @@ func (l logical) empty() bool {
 }
 
 func (l logical) ignored(ignoreTags []logicalTag) bool {
-	// A logical is ingored if ANY AND conditions match or ALL OR conditions match.
+	// A logical is ignored if ANY AND conditions match or ALL OR conditions match.
 	if len(ignoreTags) == 0 {
 		return false
 	}

--- a/doc/implementation.md
+++ b/doc/implementation.md
@@ -24,7 +24,7 @@
 		Do not integrate yet.
  - [x] Add a function to decide if a version is a label or revision.
 		A revision will either be a valid base64 string or a number without
-		any letters and greater then 100. A version will be anything else.
+		any letters and greater than 100. A version will be anything else.
 		A revision might be a short hash or long hash.
  - [x] Move existing commands to use the pkg-spec parser.
  - [x] Add common code to verify package's checksum, report package or folder trees that are not valid.


### PR DESCRIPTION
When I was updating the Debian package for govendor, the Lintian test told me the following info:

    I: govendor: spelling-error-in-binary usr/bin/govendor Choosen Chosen
    I: govendor: spelling-error-in-binary usr/bin/govendor Unkown Unknown

So I did a quick look and fixed some typos, in comments and doc only in this pull request.

There are some other typos found in the function names, as that is probably more controversial, I will be filing that in a separate pull request.

Thanks!