### PR TITLE
Query `go env` in context/get.go

### DIFF
--- a/context/get.go
+++ b/context/get.go
@@ -19,7 +19,7 @@ import (
 func Get(logger io.Writer, pkgspecName string, insecure bool) (*pkgspec.Pkg, error) {
 	// Get the GOPATHs.
 	bytebuf := new(bytes.Buffer)
-	cmd := os.exec.Command("go", "env", "GOPATH")
+	cmd := exec.Command("go", "env", "GOPATH")
 	all, err := cmd.CombinedOutput()
 	if err != nil {
 		return nil, err

--- a/context/get.go
+++ b/context/get.go
@@ -9,7 +9,6 @@ import (
 	"io"
 	"os"
 	"os/exec"
-	"bytes"
 	"path/filepath"
 
 	"github.com/kardianos/govendor/pkgspec"

--- a/context/get.go
+++ b/context/get.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"bytes"
 	"path/filepath"
 
 	"github.com/kardianos/govendor/pkgspec"
@@ -16,10 +17,13 @@ import (
 
 func Get(logger io.Writer, pkgspecName string, insecure bool) (*pkgspec.Pkg, error) {
 	// Get the GOPATHs.
-	all := os.Getenv("GOPATH")
-	if len(all) == 0 {
+	bytebuf := new(bytes.Buffer)
+	cmd := os.exec.Command("go", "env", "GOPATH")
+	cmd.Stdout = bytebuf
+	if cmd.Run() != nil {
 		return nil, ErrMissingGOPATH
 	}
+	all := cmd.Stdout.String()
 	gopathList := filepath.SplitList(all)
 	gopath := gopathList[0]
 

--- a/context/get.go
+++ b/context/get.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"os/exec"
 	"bytes"
 	"path/filepath"
 

--- a/context/get.go
+++ b/context/get.go
@@ -19,11 +19,10 @@ func Get(logger io.Writer, pkgspecName string, insecure bool) (*pkgspec.Pkg, err
 	// Get the GOPATHs.
 	bytebuf := new(bytes.Buffer)
 	cmd := os.exec.Command("go", "env", "GOPATH")
-	cmd.Stdout = bytebuf
-	if cmd.Run() != nil {
-		return nil, ErrMissingGOPATH
+	all, err := cmd.CombinedOutput()
+	if err != nil {
+		return nil, err
 	}
-	all := cmd.Stdout.String()
 	gopathList := filepath.SplitList(all)
 	gopath := gopathList[0]
 

--- a/context/get.go
+++ b/context/get.go
@@ -18,7 +18,6 @@ import (
 
 func Get(logger io.Writer, pkgspecName string, insecure bool) (*pkgspec.Pkg, error) {
 	// Get the GOPATHs.
-	bytebuf := new(bytes.Buffer)
 	cmd := exec.Command("go", "env", "GOPATH")
 	all, err := cmd.CombinedOutput()
 	if err != nil {

--- a/context/get.go
+++ b/context/get.go
@@ -23,7 +23,7 @@ func Get(logger io.Writer, pkgspecName string, insecure bool) (*pkgspec.Pkg, err
 	if err != nil {
 		return nil, err
 	}
-	gopathList := filepath.SplitList(all)
+	gopathList := filepath.SplitList(string(all))
 	gopath := gopathList[0]
 
 	cwd, err := os.Getwd()


### PR DESCRIPTION
Handles case where go environment variable is not set, uses default. Fixes #349 