### PR TITLE
Sanitize any new lines in the GOPATH

### DIFF
--- a/context/get.go
+++ b/context/get.go
@@ -22,7 +22,7 @@ func Get(logger io.Writer, pkgspecName string, insecure bool) (*pkgspec.Pkg, err
 	if err != nil {
 		return nil, err
 	}
-	gopathList := filepath.SplitList(string(all))
+	gopathList := filepath.SplitList(strings.Replace(string(all), "\n", "", -1))
 	gopath := gopathList[0]
 
 	cwd, err := os.Getwd()

--- a/context/get.go
+++ b/context/get.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 
 	"github.com/kardianos/govendor/pkgspec"
 	"golang.org/x/tools/go/vcs"


### PR DESCRIPTION
Fixes a bug where new lines in a GOPATH breaks govendor get.

Have verified it works locally.

```
liam$ govendor get github.com/gorilla/mux
Error: Package "/Users/liam/dev/go\n/src/github.com/gorilla/mux" not a go package or not in GOPATH.
```