### PR TITLE
go env GOPATH ends in a newline which has to be removed

### DIFF
--- a/context/get.go
+++ b/context/get.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 
 	"github.com/kardianos/govendor/pkgspec"
 	"golang.org/x/tools/go/vcs"
@@ -23,7 +24,7 @@ func Get(logger io.Writer, pkgspecName string, insecure bool) (*pkgspec.Pkg, err
 		return nil, err
 	}
 	gopathList := filepath.SplitList(string(all))
-	gopath := gopathList[0]
+	gopath := strings.TrimSuffix(gopathList[0], "\n")
 
 	cwd, err := os.Getwd()
 	if err != nil {


### PR DESCRIPTION
The result from `cmd.Exec("go", "env", "GOPATH")` ends in a newline, at least on my Mac and my Linux installation. If there is only one entry in GOPATH, `context.Get` tries to look up a path with a newline inserted, which fails. Trimming the newline seems to work.