### PR TITLE
Copy HasOrigin in MatchTree modification

### DIFF
--- a/context/modify.go
+++ b/context/modify.go
@@ -204,6 +204,7 @@ func (ctx *Context) ModifyImport(imp *pkgspec.Pkg, mod Modify, mops ...ModifyOpt
 			item.Pkg.HasVersion = true
 			item.Pkg.Version = imp.Version
 		}
+		item.Pkg.HasOrigin = imp.HasOrigin
 		item.Pkg.Origin = path.Join(imp.PathOrigin(), strings.TrimPrefix(item.Pkg.Path, imp.Path))
 		err = ctx.modify(item.Pkg, mod, mops)
 		if err != nil {


### PR DESCRIPTION
This fixes fetching from an origin for a tree. For example this change fixes the following set of commands such that the final result is the k8s.io/apiserver tree being fetched from github.com/kubernetes/kubernetes/staging/src/k8s.io/apiserver.

```
govendor fetch k8s.io/apiserver/...
govendor fetch k8s.io/apiserver/...@github.com/kubernetes/kubernetes/staging/src/k8s.io/apiserver
```