### PR TITLE
Get GOPATH directly from build.Default.GOPATH. Fix #335

### DIFF
--- a/context/get.go
+++ b/context/get.go
@@ -6,9 +6,9 @@ package context
 
 import (
 	"fmt"
+	"go/build"
 	"io"
 	"os"
-	"os/exec"
 	"path/filepath"
 
 	"github.com/kardianos/govendor/pkgspec"
@@ -17,12 +17,7 @@ import (
 
 func Get(logger io.Writer, pkgspecName string, insecure bool) (*pkgspec.Pkg, error) {
 	// Get the GOPATHs.
-	cmd := exec.Command("go", "env", "GOPATH")
-	all, err := cmd.CombinedOutput()
-	if err != nil {
-		return nil, err
-	}
-	gopathList := filepath.SplitList(string(all))
+	gopathList := filepath.SplitList(build.Default.GOPATH)
 	gopath := gopathList[0]
 
 	cwd, err := os.Getwd()


### PR DESCRIPTION
I want to resolve #335. Since the command "go env GOPATH" will print an '\n' at the end, we must either trim it or resort to orther approach. Note that the source code for "go env" accually sets GOPATH to build.Default.GOPATH, so we can just use it directly.