### PR TITLE
Improve recursive handling of Origin

### DIFF
--- a/context/context.go
+++ b/context/context.go
@@ -61,6 +61,8 @@ type Context struct {
 	// MoveRule provides the translation from original import path to new import path.
 	RewriteRule map[string]string // map[from]to
 
+	TreeImport []*pkgspec.Pkg
+
 	Operation []*Operation
 
 	loaded, dirty  bool

--- a/context/fetch.go
+++ b/context/fetch.go
@@ -253,6 +253,23 @@ func (f *fetcher) op(op *Operation) ([]*Operation, error) {
 				}
 			}
 
+			// Look for tree match in explicit imports
+			for _, item := range f.Ctx.TreeImport {
+				if item.Path != dep && !strings.HasPrefix(dep, item.Path+"/") {
+					continue
+				}
+				if len(item.Origin) > 0 {
+					origin = path.Join(item.PathOrigin(), strings.TrimPrefix(dep, item.Path))
+					hasOrigin = true
+				}
+				if len(item.Version) > 0 {
+					version = item.Version
+					hasVersion = true
+					revision = ""
+				}
+				break
+			}
+
 			f.HavePkg[dep] = true
 			dest := filepath.Join(f.Ctx.RootDir, f.Ctx.VendorFolder, dep)
 

--- a/context/modify.go
+++ b/context/modify.go
@@ -211,6 +211,8 @@ func (ctx *Context) ModifyImport(imp *pkgspec.Pkg, mod Modify, mops ...ModifyOpt
 			return err
 		}
 	}
+	// cache for later use
+	ctx.TreeImport = append(ctx.TreeImport, imp)
 	return nil
 }
 


### PR DESCRIPTION
Here are a few more fixes where Origin is not propagated. I'd be happy to break this up into two PRs.

The first commit handles the case where a new package is added which is in a subdirectory of an existing package. This change propagates the Origin along with the version.

The second commit handles the case where a new package is added in a second pass and the version or origin is specified on the command line. For example, a package that is not required directly by the project but is required by a newly fetched package.