### PR TITLE
allow sync/list when outside of GOPATH

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,8 @@ Uses the go1.5+ vendor folder. Multiple workflows supported, single tool.
 
 ## Notes
 
- * The project must be within a $GOPATH/src.
+ * The project must be within a `$GOPATH/src` (`sync` and `list` *are allowed*
+    when outside of `$GOPATH` however.)
  * If using go1.5, ensure you `set GO15VENDOREXPERIMENT=1`.
 
 ### Quick Start, also see the [FAQ](doc/faq.md)

--- a/context/context_test.go
+++ b/context/context_test.go
@@ -22,7 +22,7 @@ import (
 var relVendorFile = filepath.Join("vendor", "vendor.json")
 
 func ctx(g *gt.GopathTest) *Context {
-	c, err := NewContext(g.Current(), relVendorFile, "vendor", false)
+	c, err := NewContext(nil, g.Current(), relVendorFile, "vendor", false)
 	if err != nil {
 		g.Fatal(err)
 	}

--- a/context/get.go
+++ b/context/get.go
@@ -65,7 +65,7 @@ func get(logger io.Writer, gopath string, ps *pkgspec.Pkg, insecure bool) error 
 	if err != nil {
 		return err
 	}
-	ctx, err := NewContext(repoRootDir, filepath.Join("vendor", vendorFilename), "vendor", false)
+	ctx, err := NewContext(nil, repoRootDir, filepath.Join("vendor", vendorFilename), "vendor", false)
 	if err != nil {
 		return err
 	}

--- a/context/sync.go
+++ b/context/sync.go
@@ -20,7 +20,6 @@ import (
 
 	"github.com/kardianos/govendor/internal/pathos"
 	"github.com/kardianos/govendor/vendorfile"
-
 	"golang.org/x/tools/go/vcs"
 )
 

--- a/migrate/gdm.go
+++ b/migrate/gdm.go
@@ -30,7 +30,7 @@ func (sys sysGdm) Check(root string) (system, error) {
 func (sys sysGdm) Migrate(root string) error {
 	gdmFilePath := filepath.Join(root, "Godeps")
 
-	ctx, err := context.NewContext(root, filepath.Join("vendor", "vendor.json"), "vendor", false)
+	ctx, err := context.NewContext(nil, root, filepath.Join("vendor", "vendor.json"), "vendor", false)
 	if err != nil {
 		return err
 	}

--- a/migrate/glide.go
+++ b/migrate/glide.go
@@ -35,7 +35,7 @@ func (sys sysGlide) Check(root string) (system, error) {
 
 func (sys sysGlide) Migrate(root string) error {
 	// Create a new empty config.
-	ctx, err := context.NewContext(root, filepath.Join("vendor", "vendor.json"), "vendor", false)
+	ctx, err := context.NewContext(nil, root, filepath.Join("vendor", "vendor.json"), "vendor", false)
 	if err != nil {
 		return err
 	}

--- a/migrate/glock.go
+++ b/migrate/glock.go
@@ -44,7 +44,7 @@ func (sysGlock) Migrate(root string) error {
 		vf := &vendorfile.File{}
 		vf.Package = make([]*vendorfile.Package, 0, len(lines))
 	*/
-	ctx, err := context.NewContext(root, filepath.Join("vendor", "vendor.json"), "vendor", false)
+	ctx, err := context.NewContext(nil, root, filepath.Join("vendor", "vendor.json"), "vendor", false)
 	if err != nil {
 		return err
 	}

--- a/migrate/godep.go
+++ b/migrate/godep.go
@@ -37,7 +37,7 @@ func (sysGodep) Migrate(root string) error {
 	vendorPath := path.Join("Godeps", "_workspace", "src")
 	godepFilePath := filepath.Join(root, "Godeps", "Godeps.json")
 
-	ctx, err := context.NewContext(root, "vendor.json", vendorFilePath, true)
+	ctx, err := context.NewContext(nil, root, "vendor.json", vendorFilePath, true)
 	if err != nil {
 		return err
 	}

--- a/migrate/old.go
+++ b/migrate/old.go
@@ -33,7 +33,7 @@ func (sysInternal) Migrate(root string) error {
 	// Un-rewrite import paths.
 	// Copy files from internal to vendor.
 	// Update and move vendor file from "internal/vendor.json" to "vendor.json".
-	ctx, err := context.NewContext(root, filepath.Join("internal", "vendor.json"), "internal", true)
+	ctx, err := context.NewContext(nil, root, filepath.Join("internal", "vendor.json"), "internal", true)
 	if err != nil {
 		return err
 	}
@@ -84,7 +84,7 @@ func (sys sysOldVendor) Check(root string) (system, error) {
 	return nil, nil
 }
 func (sysOldVendor) Migrate(root string) error {
-	ctx, err := context.NewContext(root, "vendor.json", "vendor", false)
+	ctx, err := context.NewContext(nil, root, "vendor.json", "vendor", false)
 	if err != nil {
 		return err
 	}

--- a/run/command.go
+++ b/run/command.go
@@ -24,7 +24,7 @@ func (r *runner) Init(w io.Writer, subCmdArgs []string) (help.HelpMessage, error
 	if err != nil {
 		return help.MsgInit, err
 	}
-	ctx, err := r.NewContextWD(context.RootWD)
+	ctx, err := r.NewContextWD(nil, context.RootWD)
 	if err != nil {
 		return help.MsgNone, err
 	}
@@ -85,7 +85,7 @@ func (r *runner) Get(w io.Writer, subCmdArgs []string) (help.HelpMessage, error)
 }
 
 func (r *runner) GoCmd(subcmd string, args []string) (help.HelpMessage, error) {
-	ctx, err := r.NewContextWD(context.RootVendorOrWDOrFirstGOPATH)
+	ctx, err := r.NewContextWD(nil, context.RootVendorOrWDOrFirstGOPATH)
 	if err != nil {
 		return help.MsgNone, err
 	}
@@ -137,7 +137,7 @@ func (r *runner) Status(w io.Writer, subCmdArgs []string) (help.HelpMessage, err
 	if err != nil {
 		return help.MsgStatus, err
 	}
-	ctx, err := r.NewContextWD(context.RootVendor)
+	ctx, err := r.NewContextWD(nil, context.RootVendor)
 	if err != nil {
 		return help.MsgStatus, err
 	}

--- a/run/license.go
+++ b/run/license.go
@@ -56,7 +56,7 @@ func (r *runner) License(w io.Writer, subCmdArgs []string) (help.HelpMessage, er
 		output = f
 	}
 
-	ctx, err := r.NewContextWD(context.RootVendorOrWD)
+	ctx, err := r.NewContextWD(nil, context.RootVendorOrWD)
 	if err != nil {
 		return checkNewContextError(err)
 	}

--- a/run/list.go
+++ b/run/list.go
@@ -26,13 +26,13 @@ func (r *runner) List(w io.Writer, subCmdArgs []string) (help.HelpMessage, error
 		return help.MsgList, err
 	}
 	args := listFlags.Args()
-	// fmt.Printf("Status: %q\n", f.Status)
 
 	// Print all listed status.
-	ctx, err := r.NewContextWD(context.RootVendorOrWD)
+	ctx, err := r.NewContextWD(&context.Context{AllowExternal: true}, context.RootVendorOrWD)
 	if err != nil {
 		return checkNewContextError(err)
 	}
+
 	cgp, err := currentGoPath(ctx)
 	if err != nil {
 		return help.MsgNone, err

--- a/run/modify.go
+++ b/run/modify.go
@@ -75,14 +75,17 @@ func (r *runner) Modify(w io.Writer, subCmdArgs []string, mod context.Modify, as
 	if len(args) == 0 {
 		return msg, errors.New("missing package or status")
 	}
-	ctx, err := r.NewContextWD(context.RootVendor)
+
+	base := &context.Context{Insecure: *insecure}
+	if *verbose {
+		base.Logger = w
+	}
+
+	ctx, err := r.NewContextWD(base, context.RootVendor)
 	if err != nil {
 		return checkNewContextError(err)
 	}
-	if *verbose {
-		ctx.Logger = w
-	}
-	ctx.Insecure = *insecure
+
 	cgp, err := currentGoPath(ctx)
 	if err != nil {
 		return msg, err

--- a/run/run.go
+++ b/run/run.go
@@ -28,12 +28,12 @@ type runner struct {
 	ctx *context.Context
 }
 
-func (r *runner) NewContextWD(rt context.RootType) (*context.Context, error) {
+func (r *runner) NewContextWD(base *context.Context, rt context.RootType) (*context.Context, error) {
 	if r.ctx != nil {
 		return r.ctx, nil
 	}
 	var err error
-	r.ctx, err = context.NewContextWD(rt)
+	r.ctx, err = context.NewContextWD(base, rt)
 	return r.ctx, err
 }
 

--- a/run/sync.go
+++ b/run/sync.go
@@ -22,11 +22,14 @@ func (r *runner) Sync(w io.Writer, subCmdArgs []string) (help.HelpMessage, error
 	if err != nil {
 		return help.MsgSync, err
 	}
-	ctx, err := r.NewContextWD(context.RootVendor)
+	ctx, err := r.NewContextWD(&context.Context{
+		Insecure:      *insecure,
+		AllowExternal: true,
+	}, context.RootVendor)
 	if err != nil {
 		return help.MsgSync, err
 	}
-	ctx.Insecure = *insecure
+
 	if *dryrun || *verbose {
 		ctx.Logger = w
 	}


### PR DESCRIPTION
This PR allows `govendor sync` and `govendor list` without the requirement of being within `$GOPATH`, as mentioned in https://github.com/kardianos/govendor/issues/287 -- this allows non-Go users to easily download a package which uses govendor, without having the requirement of a valid `$GOPATH` environment setup (the `$GOPATH`-style ecosystem isn't very common, and throws newcomers off.)

As the NewContext*() methods within the context package have quite a bit of logic, with no way of easily signaling to children methods of a specific request (e.g. to not care about being in `$GOPATH`), I've opted to go the route of passing in an optional "base context" which pre-modified fields can be changed. This seems a bit more clean, rather than tacking on an additional method argument which gets passed all the way down.

I've ran tests, as well as directly tested this myself and I haven't had any issues. However, I am a bit concerned about https://github.com/lrstanley/govendor/blob/master/context/vendorFile.go#L71-L76 -- since `RootImportPath` (re: https://github.com/lrstanley/govendor/blob/master/context/context.go#L269) isn't being passed along, I am not sure if the fix for that will be affected by ignoring when we're outside of the `GOPATH`?