### PR TITLE
Add configurable cache root

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,3 +180,12 @@ Packages are identified by their name, they should contain a "/" character
 	"ignore": "test appengine foo/",
 }
 ```
+
+## Cache
+
+By default govendor stores cache in the `$GOPATH/.cache/govendor` subfolder.
+This can be changed by setting `CACHE_ROOT` environment variable.
+
+```
+CACHE_ROOT=.cache govendor sync
+```

--- a/context/context.go
+++ b/context/context.go
@@ -45,6 +45,7 @@ type Context struct {
 	RootDir        string // Full path to the project root.
 	RootGopath     string // The GOPATH the project is in.
 	RootImportPath string // The import path to the project.
+	CacheRoot      string // The path to cache directory
 
 	VendorFile       *vendorfile.File
 	VendorFilePath   string // File path to vendor file.
@@ -263,6 +264,12 @@ func NewContext(root, vendorFilePathRel, vendorFolder string, rewriteImports boo
 	if err != nil {
 		return nil, err
 	}
+
+	cacheRoot, ok := os.LookupEnv("CACHE_ROOT")
+	if !ok {
+		cacheRoot = filepath.Join(ctx.RootGopath, "..", ".cache", "govendor")
+	}
+	ctx.CacheRoot = cacheRoot
 
 	vf, err := readVendorFile(path.Join(ctx.RootImportPath, vendorFolder)+"/", vendorFilePath)
 	if err != nil {

--- a/context/sync.go
+++ b/context/sync.go
@@ -293,9 +293,7 @@ func (ctx *Context) Sync(dryrun bool) (err error) {
 	if err != nil {
 		return fmt.Errorf("Failed to verify checksums: %v", err)
 	}
-	// GOPATH includes the src dir, move up a level.
-	cacheRoot := filepath.Join(ctx.RootGopath, "..", ".cache", "govendor")
-	err = os.MkdirAll(cacheRoot, 0700)
+	err = os.MkdirAll(ctx.CacheRoot, 0700)
 	if err != nil {
 		return err
 	}
@@ -323,12 +321,12 @@ func (ctx *Context) Sync(dryrun bool) (err error) {
 		if dryrun {
 			continue
 		}
-		pkgDir := filepath.Join(cacheRoot, from)
+		pkgDir := filepath.Join(ctx.CacheRoot, from)
 
 		// See if repo exists.
-		sysVcsCmd, repoRoot, err := vcs.FromDir(pkgDir, cacheRoot)
+		sysVcsCmd, repoRoot, err := vcs.FromDir(pkgDir, ctx.CacheRoot)
 		var vcsCmd *VCSCmd
-		repoRootDir := filepath.Join(cacheRoot, repoRoot)
+		repoRootDir := filepath.Join(ctx.CacheRoot, repoRoot)
 		if err != nil {
 			rr, err := vcs.RepoRootForImportPath(from, false)
 			if err != nil {
@@ -343,7 +341,7 @@ func (ctx *Context) Sync(dryrun bool) (err error) {
 			vcsCmd = updateVcsCmd(rr.VCS)
 
 			repoRoot = rr.Root
-			repoRootDir = filepath.Join(cacheRoot, repoRoot)
+			repoRootDir = filepath.Join(ctx.CacheRoot, repoRoot)
 			err = os.MkdirAll(repoRootDir, 0700)
 			if err != nil {
 				rem = append(rem, remoteFailure{Msg: "failed to make repo root dir", Path: vp.Path, Err: err})

--- a/internal/vos/stub.go
+++ b/internal/vos/stub.go
@@ -29,6 +29,10 @@ func Getenv(key string) string {
 	return os.Getenv(key)
 }
 
+func LookupEnv(key string) (string, bool) {
+	return os.LookupEnv(key)
+}
+
 func Open(name string) (*os.File, error) {
 	l("open", name)
 	return os.Open(name)


### PR DESCRIPTION
Location of the cache root can now be modified using the `CACHE_ROOT`
environment variable. Default functionality is not affected if the
variable is not set.