### PR TITLE
fix package-spec in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ Status can be logically composed:
 ## Package specifier
 
 The full package-spec is:
-`<path>[::<origin>][{/...|/^}][@[<version-spec>]]`
+`<path>[{/...|/^}][::<origin>][@[<version-spec>]]`
 
 Some examples:
 

--- a/pkgspec/pkgspec_test.go
+++ b/pkgspec/pkgspec_test.go
@@ -22,6 +22,7 @@ func TestParse(t *testing.T) {
 		{Spec: "abc/def::foo/bar/vendor/abc/def"},
 		{Spec: "abc/def::foo/bar/vendor/abc/def@"},
 		{Spec: "abc/def::foo/bar/vendor/abc/def@v1.2.3", Pkg: &Pkg{Path: "abc/def", HasOrigin: true, Origin: "foo/bar/vendor/abc/def", HasVersion: true, Version: "v1.2.3"}},
+		{Spec: "abc/def/^::foo/bar/vendor/abc/def@v1.2.3", Pkg: &Pkg{Path: "abc/def", IncludeTree: true, HasOrigin: true, Origin: "foo/bar/vendor/abc/def", HasVersion: true, Version: "v1.2.3"}},
 		{Spec: "abc/def@", Pkg: &Pkg{Path: "abc/def", HasVersion: true}},
 		{Spec: "abc/def@v1.2.3", Pkg: &Pkg{Path: "abc/def", HasVersion: true, Version: "v1.2.3"}},
 		{Spec: "./def@v1.2.3", Str: "abc/def@v1.2.3", Pkg: &Pkg{Path: "abc/def", HasVersion: true, Version: "v1.2.3"}, WD: "abc/"},


### PR DESCRIPTION
Fix the package-spec in README.md so that it's not confusing to users
and add a test to verify the parsing of a full package spec with a path,
/^, origin, and version.