### PR TITLE
Bugfix govendor panic when git show returned warning in stderr

### DIFF
--- a/vcs/git.go
+++ b/vcs/git.go
@@ -40,7 +40,8 @@ func (VcsGit) Find(dir string) (*VcsInfo, error) {
 	cmd = exec.Command("git", "show", "--pretty=format:%H@%ai", "-s")
 
 	cmd.Dir = dir
-	output, err := cmd.CombinedOutput()
+	cmd.Stderr = nil
+	output, err := cmd.Output()
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
when using govendor to fetch large (literally really large) project from remote, it will panic w/:

```
...
	Found exact version "master"
panic: runtime error: index out of range

goroutine 1 [running]:
github.com/kardianos/govendor/vcs.VcsGit.Find(0xc00024a480, 0x58, 0x0, 0xc00024a480, 0x58)
	/Users/foo/go/src/github.com/kardianos/govendor/vcs/git.go:57 +0x578
github.com/kardianos/govendor/vcs.FindVcs(0xc0002fe120, 0x23, 0xc00024a480, 0x58, 0xc00015c088, 0x0, 0xc0004c40c0)
	/Users/foo/go/src/github.com/kardianos/govendor/vcs/vcs.go:59 +0xc1
github.com/kardianos/govendor/context.(*fetcher).op(0xc0004327c0, 0xc0005f7c20, 0x0, 0x0, 0x5b, 0x0, 0x0)
	/Users/foo/go/src/github.com/kardianos/govendor/context/fetch.go:179 +0xd6f
github.com/kardianos/govendor/context.(*Context).Alter(0xc0001ac160, 0x0, 0x0)
	/Users/foo/go/src/github.com/kardianos/govendor/context/modify.go:706 +0x48c
github.com/kardianos/govendor/run.(*runner).Modify(0xc000155e88, 0x1590620, 0xc0000be008, 0xc0000c2020, 0x3, 0x3, 0x4, 0x1590040, 0xc000155ef7, 0xc00018c240, ...)
	/Users/foo/go/src/github.com/kardianos/govendor/run/modify.go:152 +0xb74
github.com/kardianos/govendor/run.(*runner).run(0xc000155e88, 0x1590620, 0xc0000be008, 0xc0000c2000, 0x5, 0x5, 0x1590040, 0xc000155ef7, 0x152cd00, 0x0, ...)
	/Users/foo/go/src/github.com/kardianos/govendor/run/run.go:98 +0x3a5
github.com/kardianos/govendor/run.Run(0x1590620, 0xc0000be008, 0xc0000c2000, 0x5, 0x5, 0x1590040, 0xc000155ef7, 0x18b37c0, 0x150c100, 0x12)
	/Users/foo/go/src/github.com/kardianos/govendor/run/run.go:44 +0x96
main.main()
	/Users/foo/go/src/github.com/kardianos/govendor/main.go:35 +0xb2
```

according to the trace, i found that it was git returning a warning from stderr when running `git show --pretty=format:%H@%ai -s`:

```
c4a784512c43bf90fbb88aee23b1a8f9b76566d1@2018-11-07 11:39:25 +0800warning: inexact rename detection was skipped due to too many files.
warning: you may want to set your diff.renameLimit variable to at least 2410 and retry the command.
```

this pull fixes the panic by capture only stdout output from the command.


