### PR TITLE
Fix bitbucket support: Update golang.org/x/tools/go/vcs

### DIFF
--- a/vendor/golang.org/x/tools/go/vcs/discovery.go
+++ b/vendor/golang.org/x/tools/go/vcs/discovery.go
@@ -28,13 +28,16 @@ func charsetReader(charset string, input io.Reader) (io.Reader, error) {
 
 // parseMetaGoImports returns meta imports from the HTML in r.
 // Parsing ends at the end of the <head> section or the beginning of the <body>.
+//
+// This copy of cmd/go/internal/vcs.parseMetaGoImports always operates
+// in IgnoreMod ModuleMode.
 func parseMetaGoImports(r io.Reader) (imports []metaImport, err error) {
 	d := xml.NewDecoder(r)
 	d.CharsetReader = charsetReader
 	d.Strict = false
 	var t xml.Token
 	for {
-		t, err = d.Token()
+		t, err = d.RawToken()
 		if err != nil {
 			if err == io.EOF || len(imports) > 0 {
 				err = nil
@@ -55,6 +58,10 @@ func parseMetaGoImports(r io.Reader) (imports []metaImport, err error) {
 			continue
 		}
 		if f := strings.Fields(attrValue(e.Attr, "content")); len(f) == 3 {
+			// Ignore VCS type "mod", which is applicable only in module mode.
+			if f[1] == "mod" {
+				continue
+			}
 			imports = append(imports, metaImport{
 				Prefix:   f[0],
 				VCS:      f[1],

--- a/vendor/golang.org/x/tools/go/vcs/vcs.go
+++ b/vendor/golang.org/x/tools/go/vcs/vcs.go
@@ -2,6 +2,16 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+// Package vcs exposes functions for resolving import paths
+// and using version control systems, which can be used to
+// implement behavior similar to the standard "go get" command.
+//
+// This package is a copy of internal code in package cmd/go/internal/get,
+// modified to make the identifiers exported. It's provided here
+// for developers who want to write tools with similar semantics.
+// It needs to be manually kept in sync with upstream when changes are
+// made to cmd/go/internal/get; see https://golang.org/issue/11490.
+//
 package vcs // import "golang.org/x/tools/go/vcs"
 
 import (
@@ -10,6 +20,7 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"net/url"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -556,8 +567,8 @@ func RepoRootForImportDynamic(importPath string, verbose bool) (*RepoRoot, error
 		}
 	}
 
-	if !strings.Contains(metaImport.RepoRoot, "://") {
-		return nil, fmt.Errorf("%s: invalid repo root %q; no scheme", urlStr, metaImport.RepoRoot)
+	if err := validateRepoRoot(metaImport.RepoRoot); err != nil {
+		return nil, fmt.Errorf("%s: invalid repo root %q: %v", urlStr, metaImport.RepoRoot, err)
 	}
 	rr := &RepoRoot{
 		VCS:  ByCmd(metaImport.VCS),
@@ -570,6 +581,19 @@ func RepoRootForImportDynamic(importPath string, verbose bool) (*RepoRoot, error
 	return rr, nil
 }
 
+// validateRepoRoot returns an error if repoRoot does not seem to be
+// a valid URL with scheme.
+func validateRepoRoot(repoRoot string) error {
+	url, err := url.Parse(repoRoot)
+	if err != nil {
+		return err
+	}
+	if url.Scheme == "" {
+		return errors.New("no scheme")
+	}
+	return nil
+}
+
 // metaImport represents the parsed <meta name="go-import"
 // content="prefix vcs reporoot" /> tags from HTML files.
 type metaImport struct {
@@ -579,15 +603,28 @@ type metaImport struct {
 // errNoMatch is returned from matchGoImport when there's no applicable match.
 var errNoMatch = errors.New("no import match")
 
+// pathPrefix reports whether sub is a prefix of s,
+// only considering entire path components.
+func pathPrefix(s, sub string) bool {
+	// strings.HasPrefix is necessary but not sufficient.
+	if !strings.HasPrefix(s, sub) {
+		return false
+	}
+	// The remainder after the prefix must either be empty or start with a slash.
+	rem := s[len(sub):]
+	return rem == "" || rem[0] == '/'
+}
+
 // matchGoImport returns the metaImport from imports matching importPath.
 // An error is returned if there are multiple matches.
 // errNoMatch is returned if none match.
 func matchGoImport(imports []metaImport, importPath string) (_ metaImport, err error) {
 	match := -1
 	for i, im := range imports {
-		if !strings.HasPrefix(importPath, im.Prefix) {
+		if !pathPrefix(importPath, im.Prefix) {
 			continue
 		}
+
 		if match != -1 {
 			err = fmt.Errorf("multiple meta tags match import path %q", importPath)
 			return
@@ -611,15 +648,6 @@ func expand(match map[string]string, s string) string {
 
 // vcsPaths lists the known vcs paths.
 var vcsPaths = []*vcsPath{
-	// go.googlesource.com
-	{
-		prefix: "go.googlesource.com",
-		re:     `^(?P<root>go\.googlesource\.com/[A-Za-z0-9_.\-]+/?)$`,
-		vcs:    "git",
-		repo:   "https://{root}",
-		check:  noVCSSuffix,
-	},
-
 	// Github
 	{
 		prefix: "github.com/",
@@ -694,7 +722,7 @@ func bitbucketVCS(match map[string]string) error {
 	var resp struct {
 		SCM string `json:"scm"`
 	}
-	url := expand(match, "https://api.bitbucket.org/1.0/repositories/{bitname}")
+	url := expand(match, "https://api.bitbucket.org/2.0/repositories/{bitname}?fields=scm")
 	data, err := httpGET(url)
 	if err != nil {
 		return err

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -33,10 +33,10 @@
 			"revisionTime": "2019-04-19T09:16:35Z"
 		},
 		{
-			"checksumSHA1": "ULu8vRll6GP40qFH7OrHVcDSUOc=",
+			"checksumSHA1": "3MMloGEeOp5DSWVD80vbdIekTSo=",
 			"path": "golang.org/x/tools/go/vcs",
-			"revision": "70252dea49c01dbfc3f800978304eb00eb15b698",
-			"revisionTime": "2018-02-09T16:58:40Z"
+			"revision": "d73e1c7e250b19f9948138e2df37cea712e8f06f",
+			"revisionTime": "2019-06-11T22:07:34Z"
 		},
 		{
 			"checksumSHA1": "fALlQNY1fM99NesfLJ50KguWsio=",


### PR DESCRIPTION
The former version use deprecated apis of bitbucket that are no longer usable.