### PR TITLE
Update README.md to reflect that ignored packages cannot end in "/"

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,9 +198,9 @@ listed, and thus not vendored.
 
 To exclude packages, also use the "ignore" field of the "vendor.json" file.
 Packages are identified by their name, they should contain a "/" character
-(possibly at the end):
+(but not at the end):
 ```
 {
-	"ignore": "test appengine foo/",
+	"ignore": "test appengine foo/bar",
 }
 ```


### PR DESCRIPTION
At https://github.com/kardianos/govendor/blob/e07957427183a9892f35634ffc9ea48dedc6bbb4/context/resolve.go#L215, we add "/" to the prefix expected for excluded package names, so package ignores ending with "/" will not match.  I'm not sure if this was intended or not -- perhaps we should be stripping the trailing slash off before we store the excluded package name -- but it is current behavior.